### PR TITLE
Add (some) vim keys

### DIFF
--- a/src/moar.rb
+++ b/src/moar.rb
@@ -825,30 +825,36 @@ eos
     when Curses::Key::RESIZE
       # Do nothing; draw_screen() will be called anyway between all
       # keypresses
-    when Curses::Key::DOWN, 10  # 10=RETURN on a Powebook
+    when Curses::Key::DOWN, 'j', 'e', 10  # 10=RETURN on a Powebook
       @first_line += 1
       @mode = :viewing
-    when Curses::Key::UP
+    when Curses::Key::UP, 'k', 'y'
       @first_line -= 1
       @mode = :viewing
-    when Curses::Key::RIGHT
+    when Curses::Key::RIGHT, 'l'
       @first_column += 16
       @mode = :viewing
-    when Curses::Key::LEFT
+    when Curses::Key::LEFT, 'h'
       @first_column -= 16
       @first_column = 0 if @first_column < 0
       @mode = :viewing
-    when Curses::Key::NPAGE, ' '[0]
+    when Curses::Key::NPAGE, 'f', ' '[0]
       @first_line = last_line + 1
       @mode = :viewing
-    when Curses::Key::PPAGE
+    when Curses::Key::PPAGE, 'b'
       self.last_line = first_line - 1
       @mode = :viewing
-    when '<'
+    when 'd'
+      @first_line = (first_line + last_line)/2
+      @mode = :viewing
+    when 'u'
+      self.last_line = (first_line + last_line)/2
+      @mode = :viewing
+    when '<', 'g'
       @first_line = 0
       @first_column = 0
       @mode = :viewing
-    when '>'
+    when '>', 'G'
       @first_line = @lines.size
       @first_column = 0
       @mode = :viewing


### PR DESCRIPTION
I was shocked these weren't in here. Kind of a dealbreaker for a drop-in `less` replacement, don't ya think?

There are more keys missing that are fairly well documented by less itself (e.g. ZZ to quit), but these are the ones I care about.

Anyway, keep up the good work. I'm loving the "Ruby generation" of *nix tools.
