### PR TITLE
Add DeInit variable

### DIFF
--- a/m/embed-api.go
+++ b/m/embed-api.go
@@ -25,6 +25,7 @@ func Page(reader *Reader) error {
 		if DeInit {
 			screen.Fini()
 		} else {
+			// See: https://github.com/walles/moar/pull/39
 			w, h := screen.Size()
 			screen.ShowCursor(0, h - 1)
 			for x := 0; x < w; x++ {

--- a/m/embed-api.go
+++ b/m/embed-api.go
@@ -2,6 +2,10 @@ package m
 
 import "github.com/gdamore/tcell/v2"
 
+// If true, the Page function will clear the screen on return. If false, the
+// Page function will clear the last line, and show the cursor.
+var DeInit = true
+
 // Page displays text in a pager.
 //
 // The reader parameter can be constructed using one of:
@@ -17,7 +21,18 @@ func Page(reader *Reader) error {
 		// Screen setup failed
 		return e
 	}
-	defer screen.Fini()
+	defer func() {
+		if DeInit {
+			screen.Fini()
+		} else {
+			w, h := screen.Size()
+			screen.ShowCursor(0, h - 1)
+			for x := 0; x < w; x++ {
+				screen.SetContent(x, h - 1, ' ', nil, tcell.StyleDefault)
+			}
+			screen.Show()
+		}
+	}()
 
 	NewPager(reader).StartPaging(screen)
 	return nil


### PR DESCRIPTION
This allows users to control whether the screen is cleared on return. Default is
to clear the screen. Example use:

~~~go
r := m.NewReaderFromText("dir", strings.Repeat("north\n", 99))
m.DeInit = false
m.Page(r)
~~~

Fixes #33