### PR TITLE
Expose ShowLineNumbers

### DIFF
--- a/m/pager.go
+++ b/m/pager.go
@@ -42,7 +42,8 @@ type Pager struct {
 	isShowingHelp bool
 	preHelpState  *_PreHelpState
 
-	showLineNumbers bool
+	// NewPager shows lines by default, this field can hide them
+	ShowLineNumbers bool
 }
 
 type _PreHelpState struct {

--- a/m/pager.go
+++ b/m/pager.go
@@ -108,7 +108,7 @@ func NewPager(r *Reader) *Pager {
 		reader:            r,
 		quit:              false,
 		firstLineOneBased: 1,
-		showLineNumbers:   true,
+		ShowLineNumbers:   true,
 	}
 }
 
@@ -223,7 +223,7 @@ func (p *Pager) _AddLines(spinner string) {
 		numberPrefixLength = 4
 	}
 
-	if !p.showLineNumbers {
+	if !p.ShowLineNumbers {
 		numberPrefixLength = 0
 	}
 
@@ -518,13 +518,13 @@ func (p *Pager) _OnSearchKey(key tcell.Key) {
 }
 
 func (p *Pager) _MoveRight(delta int) {
-	if p.showLineNumbers && delta > 0 {
-		p.showLineNumbers = false
+	if p.ShowLineNumbers && delta > 0 {
+		p.ShowLineNumbers = false
 		return
 	}
 
 	if p.leftColumnZeroBased == 0 && delta < 0 {
-		p.showLineNumbers = true
+		p.ShowLineNumbers = true
 		return
 	}
 

--- a/m/pager_test.go
+++ b/m/pager_test.go
@@ -97,7 +97,7 @@ func TestBrokenUtf8(t *testing.T) {
 func startPaging(t *testing.T, reader *Reader) []tcell.SimCell {
 	screen := tcell.NewSimulationScreen("UTF-8")
 	pager := NewPager(reader)
-	pager.showLineNumbers = false
+	pager.ShowLineNumbers = false
 	pager.Quit()
 
 	var loglines strings.Builder


### PR DESCRIPTION
Currently the library has no way to configure line numbers, so they are just forced on for all programs. Leave NewPager default as is, but expose option so numbers can be turned off if wanted.