### PR TITLE
m: make Page a method

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,12 @@ import (
 )
 
 func main() {
-	buf := bytes.Buffer{}
-	fmt.Fprintln(&buf, "March")
-	fmt.Fprintln(&buf, "April")
+	buf := new(bytes.Buffer)
+	for range [99]struct{}{} {
+		fmt.Fprintln(buf, "Moar")
+	}
 
-	err := m.Page(m.NewReaderFromStream("Months", &buf))
+	err := m.NewPager(m.NewReaderFromStream("Moar", buf)).Page()
 	if err != nil {
 		// Handle paging problems
 		panic(err)
@@ -99,7 +100,7 @@ func main() {
 }
 ```
 
-The `m.Page()` parameter can also be initialized using `NewReaderFromText()` or
+`m.Reader` can also be initialized using `NewReaderFromText()` or
 `NewReaderFromFilename()`.
 
 Developing

--- a/m/embed-api.go
+++ b/m/embed-api.go
@@ -2,39 +2,27 @@ package m
 
 import "github.com/gdamore/tcell/v2"
 
-// If true, the Page function will clear the screen on return. If false, the
-// Page function will clear the last line, and show the cursor.
-var DeInit = true
-
 // Page displays text in a pager.
-//
-// The reader parameter can be constructed using one of:
-// * NewReaderFromFilename()
-// * NewReaderFromText()
-// * NewReaderFromStream()
-//
-// Or your could roll your own Reader based on the source code for any of those
-// constructors.
-func Page(reader *Reader) error {
+func (p *Pager) Page() error {
 	screen, e := tcell.NewScreen()
 	if e != nil {
 		// Screen setup failed
 		return e
 	}
 	defer func() {
-		if DeInit {
+		if p.DeInit {
 			screen.Fini()
-		} else {
-			// See: https://github.com/walles/moar/pull/39
-			w, h := screen.Size()
-			screen.ShowCursor(0, h - 1)
-			for x := 0; x < w; x++ {
-				screen.SetContent(x, h - 1, ' ', nil, tcell.StyleDefault)
-			}
-			screen.Show()
+			return
 		}
+		// See: https://github.com/walles/moar/pull/39
+		w, h := screen.Size()
+		screen.ShowCursor(0, h - 1)
+		for x := 0; x < w; x++ {
+			screen.SetContent(x, h - 1, ' ', nil, tcell.StyleDefault)
+		}
+		screen.Show()
 	}()
 
-	NewPager(reader).StartPaging(screen)
+	p.StartPaging(screen)
 	return nil
 }

--- a/m/pager.go
+++ b/m/pager.go
@@ -44,6 +44,10 @@ type Pager struct {
 
 	// NewPager shows lines by default, this field can hide them
 	ShowLineNumbers bool
+
+	// If true, pager will clear the screen on return. If false, pager will
+	// clear the last line, and show the cursor.
+	DeInit bool
 }
 
 type _PreHelpState struct {
@@ -109,6 +113,7 @@ func NewPager(r *Reader) *Pager {
 		quit:              false,
 		firstLineOneBased: 1,
 		ShowLineNumbers:   true,
+		DeInit:            true,
 	}
 }
 


### PR DESCRIPTION
`Page` is a great function, but it is limited, because it makes too many choices for the user. The global `DeInit` was a good start, but really that shouldve always been a `Pager` field.

Move `DeInit` inside `Pager`, and set default to `true` as before in the `NewPager` function. Then, users can call `Page`, but still have control over `DeInit`, as well as Line Numbers, and not have to worry about creating a Screen. Example code:

~~~go
r := m.NewReaderFromText("moar", strings.Repeat("moar\n", 99))
p := m.NewPager(r)
p.DeInit, p.ShowLineNumbers = false, false
p.Page()
~~~