### PR TITLE
DeInit: make output copy friendly

### DIFF
--- a/m/ansiTokenizer.go
+++ b/m/ansiTokenizer.go
@@ -21,6 +21,7 @@ var sgrSequencePattern = regexp.MustCompile("\x1b\\[([0-9;]*m)")
 
 // A Line represents a line of text that can / will be paged
 type Line struct {
+	done  bool
 	raw   *string
 	plain *string
 	cells []twin.Cell
@@ -48,13 +49,13 @@ func (line *Line) Plain() string {
 }
 
 func (line *Line) parse() {
-	if line.raw == nil {
+	if line.done {
 		// Already done
 		return
 	}
 
 	line.cells, line.plain = cellsFromString(*line.raw)
-	line.raw = nil
+	line.done = true
 }
 
 // SetManPageFormatFromEnv parses LESS_TERMCAP_xx environment variables and

--- a/m/embed-api.go
+++ b/m/embed-api.go
@@ -1,6 +1,9 @@
 package m
 
-import "github.com/walles/moar/twin"
+import (
+	"fmt"
+	"github.com/walles/moar/twin"
+)
 
 // Page displays text in a pager.
 func (p *Pager) Page() error {
@@ -10,19 +13,15 @@ func (p *Pager) Page() error {
 		return e
 	}
 	defer func() {
-		if p.DeInit {
-			screen.Close()
-			return
-		}
+		screen.Close()
+		if p.DeInit { return }
 
-		// See: https://github.com/walles/moar/pull/39
 		// FIXME: Consider moving this logic into the twin package.
-		w, h := screen.Size()
-		screen.ShowCursorAt(0, h-1)
-		for x := 0; x < w; x++ {
-			screen.SetCell(x, h-1, twin.NewCell(' ', twin.StyleDefault))
+		_, height := p.screen.Size()
+		lines := p.reader.GetLines(p.firstLineOneBased, height-1).lines
+		for _, line := range lines {
+			fmt.Println(*line.raw)
 		}
-		screen.Show()
 	}()
 
 	p.StartPaging(screen)

--- a/m/embed-api.go
+++ b/m/embed-api.go
@@ -14,7 +14,9 @@ func (p *Pager) Page() error {
 	}
 	defer func() {
 		screen.Close()
-		if p.DeInit { return }
+		if p.DeInit {
+			return
+		}
 
 		// FIXME: Consider moving this logic into the twin package.
 		_, height := p.screen.Size()


### PR DESCRIPTION
With `DeInit` turned off, the current output cannot be usefully copied, as no newlines are emitted. Close the screen in all cases now, but if `DeInit` is disabled, reprint the current buffer with newlines after the screen is closed.

Fixes #51