### PR TITLE
Let golangci-lint do all linting

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,3 @@
+linters:
+  enable:
+    - gofmt

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: go
 go:
   - 1.16.x
 
+before_script:
+  # Install golangci-lint. Latest version here if you want to bump it, version
+  # number is at the end of the "curl | sh" commandline below:
+  # https://github.com/golangci/golangci-lint/releases/latest
+  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.0
+
 jobs:
   include:
   - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,20 @@ language: go
 go:
   - 1.16.x
 
-before_script:
-  # Install golangci-lint. Latest version here if you want to bump it, version
-  # number is at the end of the "curl | sh" commandline below:
-  # https://github.com/golangci/golangci-lint/releases/latest
-  - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.0
-
 jobs:
   include:
-  - os: linux
-    dist: xenial
-    script: ./test.sh
-  - os: windows
-    script:
-    - go build
-    - go test -timeout 30s ./...
+    - os: linux
+      dist: xenial
+      script:
+        # golangci-lint is required by test.sh. Latest version here if you want
+        # to bump it, version number is at the end of the "curl | sh"
+        # commandline below:
+        # https://github.com/golangci/golangci-lint/releases/latest
+        - curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.44.0
+
+        - ./test.sh
+
+    - os: windows
+      script:
+        - go build
+        - go test -timeout 30s ./...

--- a/m/ansiTokenizer.go
+++ b/m/ansiTokenizer.go
@@ -479,7 +479,7 @@ func updateStyle(style twin.Style, escapeSequence string) twin.Style {
 		case "37":
 			style = style.Foreground(twin.NewColor16(7))
 		case "38":
-			var err error = nil
+			var err error
 			var color *twin.Color
 			index, color, err = consumeCompositeColor(numbers, index-1)
 			if err != nil {
@@ -508,7 +508,7 @@ func updateStyle(style twin.Style, escapeSequence string) twin.Style {
 		case "47":
 			style = style.Background(twin.NewColor16(7))
 		case "48":
-			var err error = nil
+			var err error
 			var color *twin.Color
 			index, color, err = consumeCompositeColor(numbers, index-1)
 			if err != nil {

--- a/test.sh
+++ b/test.sh
@@ -2,26 +2,7 @@
 
 set -e -o pipefail
 
-# If you want to bump this, check here for the most recent release version:
-# https://github.com/dominikh/go-tools/releases/latest
-STATICCHECK_VERSION=2020.2.3
-STATICCHECK="$(go env GOPATH)/bin/staticcheck"
-
-# If you want to bump this, check here for the most recent release version:
-# https://github.com/kisielk/errcheck/releases/latest
-ERRCHECK_VERSION=v1.6.0
-ERRCHECK="$(go env GOPATH)/bin/errcheck"
-
-# Install our linters
-echo Installing linters...
-if [ "$0" -nt "$STATICCHECK" ] ; then
-  go install "honnef.co/go/tools/cmd/staticcheck@${STATICCHECK_VERSION}"
-fi
-if [ "$0" -nt "$ERRCHECK" ] ; then
-  go install "github.com/kisielk/errcheck@${ERRCHECK_VERSION}"
-fi
-
-# Test that we only pass tcell.Color constants to these methods, not numbers
+# Test that we only pass twin colors to these methods, not numbers
 grep -En 'Foreground\([1-9]' ./*.go ./*/*.go && exit 1
 grep -En 'Background\([1-9]' ./*.go ./*/*.go && exit 1
 
@@ -30,57 +11,11 @@ echo Building sources...
 ./build.sh
 
 # Linting
-echo "Checking code formatting..."
-MISFORMATTED="$(gofmt -l -s .)"
-if [ -n "$MISFORMATTED" ]; then
-  echo >&2 "==="
-  echo >&2 "ERROR: The following files are not formatted, run './build.sh', './test.sh' or 'gofmt -s -w .' to fix:"
-  echo >&2 "$MISFORMATTED"
-  echo >&2 "==="
-  exit 1
-fi
-
-# "go vet" catches fmt-placeholders-vs-args problems (and others)
-echo "Running go vet..."
-if ! go vet . ./twin ./m ; then
-  if [ -n "${CI}" ]; then
-    echo >&2 "==="
-    echo >&2 "=== Please run './test.sh' before pushing to see the above issues locally rather than in CI"
-    echo >&2 "==="
-  fi
-  exit 1
-fi
-
-# Docs: https://staticcheck.io/docs/
-echo "Running staticcheck without tests..."
-if ! "$STATICCHECK" -tests=false -f stylish . ./... ; then
-  if [ -n "${CI}" ]; then
-    echo >&2 "==="
-    echo >&2 "=== Please run './test.sh' before pushing to see the above issues locally rather than in CI"
-    echo >&2 "==="
-  fi
-  exit 1
-fi
-echo "Running staticcheck with tests..."
-if ! "$STATICCHECK" -f stylish . ./... ; then
-  if [ -n "${CI}" ]; then
-    echo >&2 "==="
-    echo >&2 "=== Please run './test.sh' before pushing to see the above issues locally rather than in CI"
-    echo >&2 "==="
-  fi
-  exit 1
-fi
-
-# Checks for unused error return values: https://github.com/kisielk/errcheck
-echo "Running errcheck to check for unused error return values..."
-if ! "$ERRCHECK" . ./... ; then
-  if [ -n "${CI}" ]; then
-    echo >&2 "==="
-    echo >&2 "=== Please run './test.sh' before pushing to see the above issues locally rather than in CI"
-    echo >&2 "==="
-  fi
-  exit 1
-fi
+echo 'Linting, repro any errors locally using "golangci-lint run --enable gofmt"...'
+echo '  Linting without tests...'
+golangci-lint run --tests=false --enable gofmt
+echo '  Linting with tests...'
+golangci-lint run --tests=true --enable gofmt
 
 # Unit tests
 echo "Running unit tests..."

--- a/test.sh
+++ b/test.sh
@@ -11,11 +11,11 @@ echo Building sources...
 ./build.sh
 
 # Linting
-echo 'Linting, repro any errors locally using "golangci-lint run --enable gofmt"...'
+echo 'Linting, repro any errors locally using "golangci-lint run"...'
 echo '  Linting without tests...'
-golangci-lint run --tests=false --enable gofmt
+golangci-lint run --tests=false
 echo '  Linting with tests...'
-golangci-lint run --tests=true --enable gofmt
+golangci-lint run --tests=true
 
 # Unit tests
 echo "Running unit tests..."

--- a/twin/screen.go
+++ b/twin/screen.go
@@ -58,11 +58,11 @@ type UnixScreen struct {
 	events chan Event
 
 	ttyIn            *os.File
-	oldTerminalState *term.State //lint:ignore U1000 Not used on Windows
-	oldTtyInMode     uint32      //lint:ignore U1000 Windows only
+	oldTerminalState *term.State //nolint Not used on Windows
+	oldTtyInMode     uint32      //nolint Windows only
 
 	ttyOut        *os.File
-	oldTtyOutMode uint32 //lint:ignore U1000 Windows only
+	oldTtyOutMode uint32 //nolint Windows only
 }
 
 // Example event: "\x1b[<65;127;41M"


### PR DESCRIPTION
- Replace all linting with golangci-lint
- Move golangci-lint config into a config file
- Fix a linter reported problem
- golangci-lintify linter exclusions
