### PR TITLE
Change / in the screenlines to |

### DIFF
--- a/m/screenLines.go
+++ b/m/screenLines.go
@@ -60,9 +60,9 @@ func (p *Pager) redraw(spinner string) {
 		p.addGotoLineFooter()
 
 	case _Viewing:
-		helpText := "Press 'ESC' / 'q' to exit, '/' to search, '?' for help"
+		helpText := "Press 'ESC' | 'q' to exit, '/' to search, '?' for help"
 		if p.isShowingHelp {
-			helpText = "Press 'ESC' / 'q' to exit help, '/' to search"
+			helpText = "Press 'ESC' | 'q' to exit help, '/' to search"
 		}
 
 		if p.ShowStatusBar {


### PR DESCRIPTION
modified:   m/screenLines.go

old "Press 'ESC' / 'q' to exit, '/' to search, '?' for help"

new "Press 'ESC' | 'q' to exit, '/' to search, '?' for help"

This don't make it easier to understand? Or i'm overcomplicating?