### PR TITLE
Fix +number flag handling

### DIFF
--- a/moar.go
+++ b/moar.go
@@ -422,7 +422,7 @@ func main() {
 	stdoutIsRedirected := !term.IsTerminal(int(os.Stdout.Fd()))
 	var inputFilename *string
 	if len(remainingArgs) == 1 {
-		word := flagSet.Arg(0)
+		word := remainingArgs[0]
 		inputFilename = &word
 
 		// Need to check before twin.NewScreen() below, otherwise the screen


### PR DESCRIPTION
In v.0.17.0 only `moar file +123` works and after this `moar +123 file` works too.
Flags after `+123` aren't parsed anyway, eg: `moar +123 -trace file` fails, so it's not really a proper fix :)
I guess flagset.Parse could be called again after parsing `+` flag but I haven't looked into it more.