### PR TITLE
keys.go: Allow alternative Home/End key encoding

### DIFF
--- a/twin/keys.go
+++ b/twin/keys.go
@@ -64,6 +64,8 @@ var escapeSequenceToKeyCode = map[string]KeyCode{
 
 	"\x1b[H":  KeyHome,
 	"\x1b[F":  KeyEnd,
+	"\x1b[1~": KeyHome,
+	"\x1b[4~": KeyEnd,
 	"\x1b[5~": KeyPgUp,
 	"\x1b[6~": KeyPgDown,
 }


### PR DESCRIPTION
My setup is Tmux running in Alacritty on Debian Linux running on Chrome OS.
Before this change, Home and End keys did not work for me inside Tmux.
(Outside tmux, I don't think there was a problem).

I got the required sequences by running `cat` and pressing Home/End.

This looks similar to (or possibly the opposite of)
https://github.com/walles/moar/commit/daafbcdac4cc826d670a58bf9a6f9ef495159997.
The reference in that commit mentions these sequences for Home and End, these
kinds of sequences were already used for Delete, PgUp, and PgDown. 

For reference, the missing `\x1b[2~`  sequence would correspond to the Insert
key.