### PR TITLE
Limit right paging to text

### DIFF
--- a/m/pager.go
+++ b/m/pager.go
@@ -99,6 +99,9 @@ type Pager struct {
 	// ChromaStyle and ChromaFormatter. Used for coloring unstyled text lines
 	// based on the Chroma style.
 	linePrefix string
+
+	// Length of the longest line displayed. This is used for limiting scrolling to the right.
+	longestLineLength int
 }
 
 type _PreHelpState struct {
@@ -242,6 +245,12 @@ func (p *Pager) moveRight(delta int) {
 		p.leftColumnZeroBased = 0
 	} else {
 		p.leftColumnZeroBased = result
+	}
+
+	// If we try to move past the characters when moving right, stop scrolling to
+	// avoid moving infinitely into the void.
+	if p.leftColumnZeroBased > p.longestLineLength {
+		p.leftColumnZeroBased = p.longestLineLength
 	}
 }
 

--- a/m/screenLines.go
+++ b/m/screenLines.go
@@ -2,6 +2,7 @@ package m
 
 import (
 	"fmt"
+
 	"github.com/walles/moar/twin"
 )
 
@@ -156,30 +157,20 @@ func (p *Pager) renderLines() ([]renderedLine, string, overflowState) {
 			screenOverflow = didOverflow
 		}
 
+		var onScreenLength int
+		for i := 0; i < len(rendering); i++ {
+			trimmedLen := len(twin.TrimSpaceRight(rendering[i].cells))
+			if trimmedLen > onScreenLength {
+				onScreenLength = trimmedLen
+			}
+		}
+
 		// We're trying to find the max length of readable characters to limit
 		// the scrolling to right, so we don't go over into the vast emptiness for no reason.
-		var displayLength int
-
-		// If the line is split, we need to find the longest part of non-whitespace characters.
-		// (Or I guess, characters interpreted by human eyes as something to read)
-		if len(rendering) > 1 {
-			maxLen := len(twin.TrimSpaceRight(rendering[0].cells))
-			for i := 1; i < len(rendering); i++ {
-				trimmedLen := len(twin.TrimSpaceRight(rendering[i].cells))
-				if trimmedLen > maxLen {
-					maxLen = trimmedLen
-				}
-			}
-
-			// This limits the scrolling to, either, the max displayed line length, or the screen size
-			// if word-wrap is on.
-			// The -1 fixed an issue that seemed like an off-by-one where sometimes, when first
-			// scrolling completely to the right, the first left scroll did not show the text again.
-			displayLength = p.leftColumnZeroBased + maxLen - 1
-		} else {
-			// If the line is not split, we just take the length of the plain line.
-			displayLength = len(line.Plain(&lineNumber))
-		}
+		//
+		// The -1 fixed an issue that seemed like an off-by-one where sometimes, when first
+		// scrolling completely to the right, the first left scroll did not show the text again.
+		displayLength := p.leftColumnZeroBased + onScreenLength - 1
 
 		if displayLength >= p.longestLineLength {
 			p.longestLineLength = displayLength

--- a/m/screenLines.go
+++ b/m/screenLines.go
@@ -2,7 +2,6 @@ package m
 
 import (
 	"fmt"
-
 	"github.com/walles/moar/twin"
 )
 
@@ -33,6 +32,7 @@ type renderedLine struct {
 // the bottom
 func (p *Pager) redraw(spinner string) overflowState {
 	p.screen.Clear()
+	p.longestLineLength = 0
 
 	lastUpdatedScreenLineNumber := -1
 	var renderedScreenLines [][]twin.Cell
@@ -147,6 +147,7 @@ func (p *Pager) renderLines() ([]renderedLine, string, overflowState) {
 
 	allLines := make([]renderedLine, 0)
 	for lineIndex, line := range inputLines.lines {
+
 		lineNumber := inputLines.firstLineOneBased + lineIndex
 
 		rendering, lineOverflow := p.renderLine(line, lineNumber, p.scrollPosition.internalDontTouch)
@@ -154,6 +155,36 @@ func (p *Pager) renderLines() ([]renderedLine, string, overflowState) {
 			// Everything did not fit
 			screenOverflow = didOverflow
 		}
+
+		// We're trying to find the max length of readable characters to limit
+		// the scrolling to right, so we don't go over into the vast emptiness for no reason.
+		var displayLength int
+
+		// If the line is split, we need to find the longest part of non-whitespace characters.
+		// (Or I guess, characters interpreted by human eyes as something to read)
+		if len(rendering) > 1 {
+			maxLen := len(twin.TrimSpaceRight(rendering[0].cells))
+			for i := 1; i < len(rendering); i++ {
+				trimmedLen := len(twin.TrimSpaceRight(rendering[i].cells))
+				if trimmedLen > maxLen {
+					maxLen = trimmedLen
+				}
+			}
+
+			// This limits the scrolling to, either, the max displayed line length, or the screen size
+			// if word-wrap is on.
+			// The -1 fixed an issue that seemed like an off-by-one where sometimes, when first
+			// scrolling completely to the right, the first left scroll did not show the text again.
+			displayLength = p.leftColumnZeroBased + maxLen - 1
+		} else {
+			// If the line is not split, we just take the length of the plain line.
+			displayLength = len(line.Plain(&lineNumber))
+		}
+
+		if displayLength >= p.longestLineLength {
+			p.longestLineLength = displayLength
+		}
+
 		allLines = append(allLines, rendering...)
 	}
 
@@ -260,6 +291,7 @@ func (p *Pager) decorateLine(lineNumberToShow *int, contents []twin.Cell, scroll
 		if endColumn > len(contents) {
 			endColumn = len(contents)
 		}
+
 		newLine = append(newLine, contents[startColumn:endColumn]...)
 	}
 


### PR DESCRIPTION
Hi!

**The change:**
When paging right, it was possible to infinitely go to the right. This changes that so it is only possible to go right until the last visible character is out of the screen. Only the lines that are currently on screen are taken into account for the limit.

-----------------------

I'm not sure if this change is wanted by anyone but me, but, suspiciously often, I somehow end up scrolling way past the end of the text to the right so I've decided to make a change to stop that from happening.

I figured I'd make a PR in case this behavior is something more people want, if not, feel free to close.

Also, the limit ignores whitespace to the right of the characters.
I've only tested with a few sample files, and not all options though. If needed, I can test a bit more comprehensively and make changes to the code.