### PR TITLE
Use Revive for finding unused code

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -22,7 +22,7 @@ jobs:
       # commandline below:
       # https://github.com/golangci/golangci-lint/releases/latest
       - name: Install golangci-lint
-        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.51.2
+        run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b "$(go env GOPATH)"/bin v1.54.1
 
       - run: ./test.sh
       - run: GOARCH=386 ./test.sh

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,5 @@
 linters:
   enable:
     - gofmt
-
-    # I'd really want to use Revive for this but that doesn't work:
-    # https://github.com/golangci/golangci-lint/issues/3653
-    - unparam
-
+    - revive
     - usestdlibvars

--- a/m/ansiTokenizer.go
+++ b/m/ansiTokenizer.go
@@ -34,6 +34,8 @@ func NewLine(raw string) Line {
 
 // Returns a representation of the string split into styled tokens. Any regexp
 // matches are highlighted. A nil regexp means no highlighting.
+//
+//revive:disable-next-line:unexported-return
 func (line *Line) HighlightedTokens(linePrefix string, search *regexp.Regexp, lineNumberOneBased *int) cellsWithTrailer {
 	plain := line.Plain(lineNumberOneBased)
 	matchRanges := getMatchRanges(&plain, search)

--- a/m/ansiTokenizer_test.go
+++ b/m/ansiTokenizer_test.go
@@ -41,6 +41,7 @@ func TestTokenize(t *testing.T) {
 			}()
 
 			myReader := NewReaderFromStream(fileName, file)
+			//revive:disable-next-line:empty-block
 			for !myReader.done.Load() {
 			}
 

--- a/m/highlight.go
+++ b/m/highlight.go
@@ -12,6 +12,8 @@ import (
 )
 
 // Files larger than this won't be highlighted
+//
+//revive:disable-next-line:var-naming
 const MAX_HIGHLIGHT_SIZE int64 = 1024 * 1024
 
 // Read and highlight a file using Chroma: https://github.com/alecthomas/chroma

--- a/m/linewrapper.go
+++ b/m/linewrapper.go
@@ -8,6 +8,8 @@ import (
 )
 
 // From: https://www.compart.com/en/unicode/U+00A0
+//
+//revive:disable-next-line:var-naming
 const NO_BREAK_SPACE = '\xa0'
 
 func getWrapWidth(line []twin.Cell, maxWrapWidth int) int {

--- a/m/pager.go
+++ b/m/pager.go
@@ -24,8 +24,11 @@ const (
 type StatusBarOption int
 
 const (
+	//revive:disable-next-line:var-naming
 	STATUSBAR_STYLE_INVERSE StatusBarOption = iota
+	//revive:disable-next-line:var-naming
 	STATUSBAR_STYLE_PLAIN
+	//revive:disable-next-line:var-naming
 	STATUSBAR_STYLE_BOLD
 )
 
@@ -33,7 +36,9 @@ const (
 type UnprintableStyle int
 
 const (
+	//revive:disable-next-line:var-naming
 	UNPRINTABLE_STYLE_HIGHLIGHT UnprintableStyle = iota
+	//revive:disable-next-line:var-naming
 	UNPRINTABLE_STYLE_WHITESPACE
 )
 
@@ -475,7 +480,7 @@ func (p *Pager) StartPaging(screen twin.Screen, chromaStyle *chroma.Style, chrom
 
 	unprintableStyle = p.UnprintableStyle
 	consumeLessTermcapEnvs(chromaStyle, chromaFormatter)
-	styleUi(chromaStyle, chromaFormatter, p.StatusBarStyle)
+	styleUI(chromaStyle, chromaFormatter, p.StatusBarStyle)
 
 	p.screen = screen
 	p.linePrefix = getLineColorPrefix(chromaStyle, chromaFormatter)

--- a/m/pager_test.go
+++ b/m/pager_test.go
@@ -15,6 +15,8 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+//revive:disable:empty-block
+
 const blueBackgroundClearToEol0 = "\x1b[44m\x1b[0K" // With 0 before the K, should clear to EOL
 const blueBackgroundClearToEol = "\x1b[44m\x1b[K"   // No 0 before the K, should also clear to EOL
 

--- a/m/reader.go
+++ b/m/reader.go
@@ -465,58 +465,58 @@ func NewReaderFromFilename(filename string, style chroma.Style, formatter chroma
 }
 
 // createStatusUnlocked() assumes that its caller is holding the lock
-func (r *Reader) createStatusUnlocked(lastLineOneBased int) string {
+func (reader *Reader) createStatusUnlocked(lastLineOneBased int) string {
 	prefix := ""
-	if r.name != nil {
-		prefix = path.Base(*r.name) + ": "
+	if reader.name != nil {
+		prefix = path.Base(*reader.name) + ": "
 	}
 
-	if len(r.lines) == 0 {
+	if len(reader.lines) == 0 {
 		return prefix + "<empty>"
 	}
 
-	if len(r.lines) == 1 {
+	if len(reader.lines) == 1 {
 		return prefix + "1 line  100%"
 	}
 
-	percent := int(100 * float64(lastLineOneBased) / float64(len(r.lines)))
+	percent := int(100 * float64(lastLineOneBased) / float64(len(reader.lines)))
 
 	return fmt.Sprintf("%s%s lines  %d%%",
 		prefix,
-		formatNumber(uint(len(r.lines))),
+		formatNumber(uint(len(reader.lines))),
 		percent)
 }
 
 // GetLineCount returns the number of lines available for viewing
-func (r *Reader) GetLineCount() int {
-	r.Lock()
-	defer r.Unlock()
+func (reader *Reader) GetLineCount() int {
+	reader.Lock()
+	defer reader.Unlock()
 
-	return len(r.lines)
+	return len(reader.lines)
 }
 
 // GetLine gets a line. If the requested line number is out of bounds, nil is returned.
-func (r *Reader) GetLine(lineNumberOneBased int) *Line {
-	r.Lock()
-	defer r.Unlock()
+func (reader *Reader) GetLine(lineNumberOneBased int) *Line {
+	reader.Lock()
+	defer reader.Unlock()
 
 	if lineNumberOneBased < 1 {
 		return nil
 	}
-	if lineNumberOneBased > len(r.lines) {
+	if lineNumberOneBased > len(reader.lines) {
 		return nil
 	}
-	return r.lines[lineNumberOneBased-1]
+	return reader.lines[lineNumberOneBased-1]
 }
 
 // GetLines gets the indicated lines from the input
 //
 // Overflow state will be didFit if we returned all lines we currently have, or
 // didOverflow otherwise.
-func (r *Reader) GetLines(firstLineOneBased int, wantedLineCount int) (*InputLines, overflowState) {
-	r.Lock()
-	defer r.Unlock()
-	return r.getLinesUnlocked(firstLineOneBased, wantedLineCount)
+func (reader *Reader) GetLines(firstLineOneBased int, wantedLineCount int) (*InputLines, overflowState) {
+	reader.Lock()
+	defer reader.Unlock()
+	return reader.getLinesUnlocked(firstLineOneBased, wantedLineCount)
 }
 
 func nonWrappingAdd(a int, b int) int {
@@ -531,16 +531,16 @@ func nonWrappingAdd(a int, b int) int {
 	return a + b
 }
 
-func (r *Reader) getLinesUnlocked(firstLineOneBased int, wantedLineCount int) (*InputLines, overflowState) {
+func (reader *Reader) getLinesUnlocked(firstLineOneBased int, wantedLineCount int) (*InputLines, overflowState) {
 	if firstLineOneBased < 1 {
 		firstLineOneBased = 1
 	}
 
-	if len(r.lines) == 0 || wantedLineCount == 0 {
+	if len(reader.lines) == 0 || wantedLineCount == 0 {
 		return &InputLines{
 				lines:             nil,
 				firstLineOneBased: firstLineOneBased,
-				statusText:        r.createStatusUnlocked(firstLineOneBased),
+				statusText:        reader.createStatusUnlocked(firstLineOneBased),
 			},
 			didFit // Empty files always fit
 	}
@@ -548,8 +548,8 @@ func (r *Reader) getLinesUnlocked(firstLineOneBased int, wantedLineCount int) (*
 	firstLineZeroBased := firstLineOneBased - 1
 	lastLineZeroBased := nonWrappingAdd(firstLineZeroBased, wantedLineCount-1)
 
-	if lastLineZeroBased >= len(r.lines) {
-		lastLineZeroBased = len(r.lines) - 1
+	if lastLineZeroBased >= len(reader.lines) {
+		lastLineZeroBased = len(reader.lines) - 1
 	}
 
 	// Prevent reading past the end of the available lines
@@ -561,19 +561,19 @@ func (r *Reader) getLinesUnlocked(firstLineOneBased int, wantedLineCount int) (*
 			firstLineOneBased = 1
 		}
 
-		return r.getLinesUnlocked(firstLineOneBased, wantedLineCount)
+		return reader.getLinesUnlocked(firstLineOneBased, wantedLineCount)
 	}
 
-	returnLines := r.lines[firstLineZeroBased : lastLineZeroBased+1]
+	returnLines := reader.lines[firstLineZeroBased : lastLineZeroBased+1]
 	overflow := didFit
-	if len(returnLines) != len(r.lines) {
+	if len(returnLines) != len(reader.lines) {
 		overflow = didOverflow // We're not returning all available lines
 	}
 
 	return &InputLines{
 			lines:             returnLines,
 			firstLineOneBased: firstLineOneBased,
-			statusText:        r.createStatusUnlocked(lastLineZeroBased + 1),
+			statusText:        reader.createStatusUnlocked(lastLineZeroBased + 1),
 		},
 		overflow
 }

--- a/m/reader.go
+++ b/m/reader.go
@@ -513,6 +513,8 @@ func (reader *Reader) GetLine(lineNumberOneBased int) *Line {
 //
 // Overflow state will be didFit if we returned all lines we currently have, or
 // didOverflow otherwise.
+//
+//revive:disable-next-line:unexported-return
 func (reader *Reader) GetLines(firstLineOneBased int, wantedLineCount int) (*InputLines, overflowState) {
 	reader.Lock()
 	defer reader.Unlock()

--- a/m/reader_test.go
+++ b/m/reader_test.go
@@ -15,6 +15,8 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+//revive:disable:empty-block
+
 func testGetLineCount(t *testing.T, reader *Reader) {
 	if strings.Contains(*reader.name, "compressed") {
 		// We are no good at counting lines of compressed files, never mind
@@ -139,8 +141,10 @@ func getTestFiles() []string {
 // Wait for reader to finish reading and highlighting. Used by tests.
 func (r *Reader) _wait() error {
 	// Wait for our goroutine to finish
+	//revive:disable-next-line:empty-block
 	for !r.done.Load() {
 	}
+	//revive:disable-next-line:empty-block
 	for !r.highlightingDone.Load() {
 	}
 
@@ -213,7 +217,7 @@ func testHighlightingLineCount(t *testing.T, filenameWithPath string) {
 	}
 	rawLinesCount := rawLinefeedsCount
 	if !rawFileEndsWithNewline {
-		rawLinesCount += 1
+		rawLinesCount++
 	}
 
 	// Then load the same file using one of our Readers
@@ -329,15 +333,15 @@ func TestCompressedFiles(t *testing.T) {
 }
 
 func TestFilterNotInstalled(t *testing.T) {
-	// FIXME: Test what happens if we try to use a filter that is not installed
+	t.Skip("FIXME: Test what happens if we try to use a filter that is not installed")
 }
 
 func TestFilterFailure(t *testing.T) {
-	// FIXME: Test what happens if the filter command fails because of bad command line options
+	t.Skip("FIXME: Test what happens if the filter command fails because of bad command line options")
 }
 
 func TestFilterPermissionDenied(t *testing.T) {
-	// FIXME: Test what happens if the filter command fails because it can't access the requested file
+	t.Skip("FIXME: Test what happens if the filter command fails because it can't access the requested file")
 }
 
 func TestFilterFileNotFound(t *testing.T) {
@@ -357,7 +361,7 @@ func TestFilterFileNotFound(t *testing.T) {
 }
 
 func TestFilterNotAFile(t *testing.T) {
-	// FIXME: Test what happens if the filter command fails because the target is not a file
+	t.Skip("FIXME: Test what happens if the filter command fails because the target is not a file")
 }
 
 // How long does it take to read a file?
@@ -376,6 +380,7 @@ func BenchmarkReaderDone(b *testing.B) {
 		}
 
 		// Wait for the reader to finish
+		//revive:disable-next-line:empty-block
 		for !readMe.done.Load() {
 		}
 		if readMe.err != nil {
@@ -390,8 +395,8 @@ func BenchmarkReadLargeFile(b *testing.B) {
 	const largeSizeBytes = 35_000_000
 
 	// First, create it from something...
-	input_filename := getSamplesDir() + "/../m/pager.go"
-	contents, err := os.ReadFile(input_filename)
+	inputFilename := getSamplesDir() + "/../m/pager.go"
+	contents, err := os.ReadFile(inputFilename)
 	if err != nil {
 		panic(err)
 	}
@@ -436,8 +441,8 @@ func BenchmarkReadLargeFile(b *testing.B) {
 // Count lines in pager.go
 func BenchmarkCountLines(b *testing.B) {
 	// First, get some sample lines...
-	input_filename := getSamplesDir() + "/../m/pager.go"
-	contents, err := os.ReadFile(input_filename)
+	inputFilename := getSamplesDir() + "/../m/pager.go"
+	contents, err := os.ReadFile(inputFilename)
 	if err != nil {
 		panic(err)
 	}

--- a/m/screenLines_test.go
+++ b/m/screenLines_test.go
@@ -10,6 +10,8 @@ import (
 	"gotest.tools/v3/assert"
 )
 
+//revive:disable:empty-block
+
 func testHorizontalCropping(t *testing.T, contents string, firstIndex int, lastIndex int, expected string, expectedOverflow overflowState) {
 	pager := NewPager(nil)
 	pager.ShowLineNumbers = false

--- a/m/scrollPosition.go
+++ b/m/scrollPosition.go
@@ -60,23 +60,23 @@ func canonicalFromPager(pager *Pager) scrollPositionCanonical {
 }
 
 // Create a new position, scrolled towards the end of the file
-func (s scrollPosition) PreviousLine(scrollDistance int) scrollPosition {
+func (sp scrollPosition) PreviousLine(scrollDistance int) scrollPosition {
 	return scrollPosition{
 		internalDontTouch: scrollPositionInternal{
-			name:               s.internalDontTouch.name,
-			lineNumberOneBased: s.internalDontTouch.lineNumberOneBased,
-			deltaScreenLines:   s.internalDontTouch.deltaScreenLines - scrollDistance,
+			name:               sp.internalDontTouch.name,
+			lineNumberOneBased: sp.internalDontTouch.lineNumberOneBased,
+			deltaScreenLines:   sp.internalDontTouch.deltaScreenLines - scrollDistance,
 		},
 	}
 }
 
 // Create a new position, scrolled towards the end of the file
-func (s scrollPosition) NextLine(scrollDistance int) scrollPosition {
+func (sp scrollPosition) NextLine(scrollDistance int) scrollPosition {
 	return scrollPosition{
 		internalDontTouch: scrollPositionInternal{
-			name:               s.internalDontTouch.name,
-			lineNumberOneBased: s.internalDontTouch.lineNumberOneBased,
-			deltaScreenLines:   s.internalDontTouch.deltaScreenLines + scrollDistance,
+			name:               sp.internalDontTouch.name,
+			lineNumberOneBased: sp.internalDontTouch.lineNumberOneBased,
+			deltaScreenLines:   sp.internalDontTouch.deltaScreenLines + scrollDistance,
 		},
 	}
 }
@@ -168,7 +168,7 @@ func (si *scrollPositionInternal) emptyBottomLinesCount(pager *Pager) int {
 		}
 
 		// Move to the next line
-		lineNumberOneBased += 1
+		lineNumberOneBased++
 	}
 
 	return unclaimedViewportLines

--- a/m/scrollPosition.go
+++ b/m/scrollPosition.go
@@ -82,6 +82,8 @@ func (sp scrollPosition) NextLine(scrollDistance int) scrollPosition {
 }
 
 // Create a new position, scrolled to the given line number
+//
+//revive:disable-next-line:unexported-return
 func NewScrollPositionFromLineNumberOneBased(lineNumberOneBased int, source string) scrollPosition {
 	return scrollPosition{
 		internalDontTouch: scrollPositionInternal{

--- a/m/search.go
+++ b/m/search.go
@@ -70,9 +70,9 @@ func (p *Pager) findFirstHit(startPosition scrollPosition, backwards bool) *scro
 		}
 
 		if backwards {
-			searchPosition -= 1
+			searchPosition--
 		} else {
-			searchPosition += 1
+			searchPosition++
 		}
 	}
 }

--- a/m/styledStringSplitter.go
+++ b/m/styledStringSplitter.go
@@ -138,7 +138,7 @@ func (s *styledStringSplitter) consumeControlSequence(charAfterEsc rune) error {
 
 			if charAfterEsc == ']' && s.input[startIndex:s.nextByteIndex] == "8;;" {
 				// Special case, here comes the URL
-				return s.handleUrl()
+				return s.handleURL()
 			}
 
 			continue
@@ -196,9 +196,9 @@ func (s *styledStringSplitter) handleOsc(sequence string) error {
 		if endMarker == esc {
 			if s.nextChar() == '\\' {
 				return nil
-			} else {
-				return fmt.Errorf("Expected ESC \\ after ESC]133;X, got %q", s.lastChar())
 			}
+
+			return fmt.Errorf("Expected ESC \\ after ESC]133;X, got %q", s.lastChar())
 		}
 	}
 
@@ -206,7 +206,7 @@ func (s *styledStringSplitter) handleOsc(sequence string) error {
 }
 
 // We just got ESC]8; and should now read the URL. URLs end with ASCII 7 BEL or ESC \.
-func (s *styledStringSplitter) handleUrl() error {
+func (s *styledStringSplitter) handleURL() error {
 	// Valid URL characters.
 	// Ref: https://stackoverflow.com/a/1547940/473672
 	const validChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~:/?#[]@!$&'()*+,;="

--- a/m/styling.go
+++ b/m/styling.go
@@ -11,7 +11,7 @@ import (
 )
 
 // From LESS_TERMCAP_so, overrides statusbarStyle from the Chroma style if set
-var standoutStyle *twin.Style = nil
+var standoutStyle *twin.Style
 
 var manPageBold = twin.StyleDefault.WithAttr(twin.AttrBold)
 var manPageUnderline = twin.StyleDefault.WithAttr(twin.AttrUnderline)
@@ -75,7 +75,7 @@ func consumeLessTermcapEnvs(chromaStyle *chroma.Style, chromaFormatter *chroma.F
 	}
 }
 
-func styleUi(chromaStyle *chroma.Style, chromaFormatter *chroma.Formatter, statusbarOption StatusBarOption) {
+func styleUI(chromaStyle *chroma.Style, chromaFormatter *chroma.Formatter, statusbarOption StatusBarOption) {
 	if chromaStyle == nil || chromaFormatter == nil {
 		return
 	}

--- a/moar.go
+++ b/moar.go
@@ -160,7 +160,7 @@ func parseStyleOption(styleOption string) (chroma.Style, error) {
 	style, ok := styles.Registry[styleOption]
 	if !ok {
 		return *styles.Fallback, fmt.Errorf(
-			"Pick a style from here: https://xyproto.github.io/splash/docs/longer/all.html\n")
+			"Pick a style from here: https://xyproto.github.io/splash/docs/longer/all.html")
 	}
 
 	return *style, nil
@@ -187,7 +187,7 @@ func parseColorsOption(colorsOption string) (twin.ColorType, error) {
 	}
 
 	var noColor twin.ColorType
-	return noColor, fmt.Errorf("Valid counts are 8, 16, 256, 16M or auto.")
+	return noColor, fmt.Errorf("Valid counts are 8, 16, 256, 16M or auto")
 }
 
 func parseStatusBarStyle(styleOption string) (m.StatusBarOption, error) {

--- a/twin/colors.go
+++ b/twin/colors.go
@@ -217,9 +217,8 @@ func (color Color) downsampleTo(terminalColorCount ColorType) Color {
 
 	if bestMatch <= 15 {
 		return NewColor16(bestMatch)
-	} else {
-		return NewColor256(uint8(bestMatch))
 	}
+	return NewColor256(uint8(bestMatch))
 }
 
 // Wrapper for Chroma's color distance function.
@@ -228,15 +227,15 @@ func (color Color) downsampleTo(terminalColorCount ColorType) Color {
 //
 // The result from this function has been scaled to 0.0-1.0, where 1.0 is the
 // distance between black and white.
-func (c Color) Distance(other Color) float64 {
-	if c.ColorType() != ColorType24bit {
-		panic(fmt.Errorf("contrast only supported for 24 bit colors, got %s vs %s", c.String(), other.String()))
+func (color Color) Distance(other Color) float64 {
+	if color.ColorType() != ColorType24bit {
+		panic(fmt.Errorf("contrast only supported for 24 bit colors, got %s vs %s", color.String(), other.String()))
 	}
 
 	baseColor := chroma.NewColour(
-		uint8(c.colorValue()>>16&0xff),
-		uint8(c.colorValue()>>8&0xff),
-		uint8(c.colorValue()&0xff),
+		uint8(color.colorValue()>>16&0xff),
+		uint8(color.colorValue()>>8&0xff),
+		uint8(color.colorValue()&0xff),
 	)
 
 	otherColor := chroma.NewColour(

--- a/twin/fake-screen.go
+++ b/twin/fake-screen.go
@@ -72,7 +72,7 @@ func (screen *FakeScreen) Size() (width int, height int) {
 	return screen.width, screen.height
 }
 
-func (screen *FakeScreen) ShowCursorAt(column int, row int) {
+func (screen *FakeScreen) ShowCursorAt(_ int, _ int) {
 	// This method intentionally left blank
 }
 

--- a/twin/palette256.go
+++ b/twin/palette256.go
@@ -16,12 +16,12 @@ func color256ToRGB(color256 uint8) (r, g, b uint8) {
 	}
 
 	// 6x6 color cube
-	color0_to_215 := color256 - 16
+	color0to215 := color256 - 16
 
 	components := []uint8{0x00, 0x5f, 0x87, 0xaf, 0xd7, 0xff}
-	r = components[(color0_to_215/36)%6]
-	g = components[(color0_to_215/6)%6]
-	b = components[(color0_to_215/1)%6]
+	r = components[(color0to215/36)%6]
+	g = components[(color0to215/6)%6]
+	b = components[(color0to215/1)%6]
 	return r, g, b
 }
 

--- a/twin/screen.go
+++ b/twin/screen.go
@@ -94,7 +94,7 @@ type UnixScreen struct {
 // * "41" is the row number on screen, "1" is the first row.
 //
 // * "M" marks the end of the mouse event.
-var MOUSE_EVENT_REGEX = regexp.MustCompile("^\x1b\\[<([0-9]+);([0-9]+);([0-9]+)M")
+var mouseEventRegex = regexp.MustCompile("^\x1b\\[<([0-9]+);([0-9]+);([0-9]+)M")
 
 // NewScreen() requires Close() to be called after you are done with your new
 // screen, most likely somewhere in your shutdown code.
@@ -369,7 +369,7 @@ func (screen *UnixScreen) mainLoop() {
 
 // Turn ESC into <0x1b> and other low ASCII characters into <0xXX> for logging
 // purposes.
-func humanizeLowAscii(withLowAsciis string) string {
+func humanizeLowASCII(withLowAsciis string) string {
 	humanized := ""
 	for _, char := range withLowAsciis {
 		if char < ' ' {
@@ -396,7 +396,7 @@ func consumeEncodedEvent(encodedEventSequences string) (*Event, string) {
 		return &event, strings.TrimPrefix(encodedEventSequences, singleKeyCodeSequence)
 	}
 
-	mouseMatch := MOUSE_EVENT_REGEX.FindStringSubmatch(encodedEventSequences)
+	mouseMatch := mouseEventRegex.FindStringSubmatch(encodedEventSequences)
 	if mouseMatch != nil {
 		if mouseMatch[1] == "64" {
 			var event Event = EventMouse{buttons: MouseWheelUp}
@@ -409,7 +409,7 @@ func consumeEncodedEvent(encodedEventSequences string) (*Event, string) {
 
 		log.Debug(
 			"Unhandled multi character mouse escape sequence(s): {",
-			humanizeLowAscii(encodedEventSequences),
+			humanizeLowASCII(encodedEventSequences),
 			"}")
 		return nil, ""
 	}
@@ -426,7 +426,7 @@ func consumeEncodedEvent(encodedEventSequences string) (*Event, string) {
 			// escapeSequenceToKeyCode in keys.go.
 			log.Debug(
 				"Unhandled multi character terminal escape sequence(s): {",
-				humanizeLowAscii(encodedEventSequences),
+				humanizeLowASCII(encodedEventSequences),
 				"}")
 
 			// Mark everything as consumed since we don't know how to proceed otherwise.

--- a/twin/styles.go
+++ b/twin/styles.go
@@ -23,7 +23,7 @@ type Style struct {
 	bg    Color
 	attrs AttrMask
 
-	// This hyperlinkUrl is a URL for in-terminal hyperlinks.
+	// This hyperlinkURL is a URL for in-terminal hyperlinks.
 	//
 	// Since we don't want to do error handling of broken URLs, we just store
 	// these URLs as strings.
@@ -31,7 +31,7 @@ type Style struct {
 	// Ref:
 	// * https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
 	// * https://github.com/walles/moar/issues/131
-	hyperlinkUrl *string
+	hyperlinkURL *string
 }
 
 var StyleDefault Style
@@ -63,8 +63,8 @@ func (style Style) String() string {
 	if style.attrs.has(AttrStrikeThrough) {
 		attrNames = append(attrNames, "strikethrough")
 	}
-	if style.hyperlinkUrl != nil {
-		attrNames = append(attrNames, "\""+*style.hyperlinkUrl+"\"")
+	if style.hyperlinkURL != nil {
+		attrNames = append(attrNames, "\""+*style.hyperlinkURL+"\"")
 	}
 
 	return fmt.Sprint(strings.Join(attrNames, " "), " ", style.fg, " on ", style.bg)
@@ -75,7 +75,7 @@ func (style Style) WithAttr(attr AttrMask) Style {
 		fg:           style.fg,
 		bg:           style.bg,
 		attrs:        style.attrs | attr,
-		hyperlinkUrl: style.hyperlinkUrl,
+		hyperlinkURL: style.hyperlinkURL,
 	}
 
 	// Bold and dim are mutually exclusive
@@ -90,17 +90,17 @@ func (style Style) WithAttr(attr AttrMask) Style {
 }
 
 // Call with nil to remove the link
-func (style Style) WithHyperlink(hyperlinkUrl *string) Style {
-	if hyperlinkUrl != nil && *hyperlinkUrl == "" {
+func (style Style) WithHyperlink(hyperlinkURL *string) Style {
+	if hyperlinkURL != nil && *hyperlinkURL == "" {
 		// Use nil instead of empty string
-		hyperlinkUrl = nil
+		hyperlinkURL = nil
 	}
 
 	return Style{
 		fg:           style.fg,
 		bg:           style.bg,
 		attrs:        style.attrs,
-		hyperlinkUrl: hyperlinkUrl,
+		hyperlinkURL: hyperlinkURL,
 	}
 }
 
@@ -109,7 +109,7 @@ func (style Style) WithoutAttr(attr AttrMask) Style {
 		fg:           style.fg,
 		bg:           style.bg,
 		attrs:        style.attrs & ^attr,
-		hyperlinkUrl: style.hyperlinkUrl,
+		hyperlinkURL: style.hyperlinkURL,
 	}
 }
 
@@ -122,7 +122,7 @@ func (style Style) WithBackground(color Color) Style {
 		fg:           style.fg,
 		bg:           color,
 		attrs:        style.attrs,
-		hyperlinkUrl: style.hyperlinkUrl,
+		hyperlinkURL: style.hyperlinkURL,
 	}
 }
 
@@ -131,19 +131,21 @@ func (style Style) WithForeground(color Color) Style {
 		fg:           color,
 		bg:           style.bg,
 		attrs:        style.attrs,
-		hyperlinkUrl: style.hyperlinkUrl,
+		hyperlinkURL: style.hyperlinkURL,
 	}
 }
 
 // Emit an ANSI escape sequence switching from a previous style to the current
 // one.
+//
+//revive:disable-next-line:receiver-naming
 func (current Style) RenderUpdateFrom(previous Style, terminalColorCount ColorType) string {
 	if current == previous {
 		// Shortcut for the common case
 		return ""
 	}
 
-	hadHyperlink := previous.hyperlinkUrl != nil && *previous.hyperlinkUrl != ""
+	hadHyperlink := previous.hyperlinkURL != nil && *previous.hyperlinkURL != ""
 	if current == StyleDefault && !hadHyperlink {
 		return "\x1b[m"
 	}
@@ -217,20 +219,20 @@ func (current Style) RenderUpdateFrom(previous Style, terminalColorCount ColorTy
 		}
 	}
 
-	if current.hyperlinkUrl != previous.hyperlinkUrl {
-		newUrl := ""
-		if current.hyperlinkUrl != nil {
-			newUrl = *current.hyperlinkUrl
+	if current.hyperlinkURL != previous.hyperlinkURL {
+		newURL := ""
+		if current.hyperlinkURL != nil {
+			newURL = *current.hyperlinkURL
 		}
 
-		previousUrl := ""
-		if previous.hyperlinkUrl != nil {
-			previousUrl = *previous.hyperlinkUrl
+		previousURL := ""
+		if previous.hyperlinkURL != nil {
+			previousURL = *previous.hyperlinkURL
 		}
 
-		if newUrl != previousUrl {
+		if newURL != previousURL {
 			builder.WriteString("\x1b]8;;")
-			builder.WriteString(newUrl)
+			builder.WriteString(newURL)
 			builder.WriteString("\x1b\\")
 		}
 	}


### PR DESCRIPTION
- Enable revive for unused parameters check
- Disable warnings for existing issues
- Handle warnings in twin
- Handle warnings in moar.go
- Bump CI version of golangci-lint
