### PR TITLE
Add a -lang option for setting the highlighting language

### DIFF
--- a/m/highlight.go
+++ b/m/highlight.go
@@ -13,15 +13,11 @@ import (
 //revive:disable-next-line:var-naming
 const MAX_HIGHLIGHT_SIZE int64 = 1024 * 1024
 
-// Read and highlight a file using Chroma: https://github.com/alecthomas/chroma
-//
-// The format can be a filename, a MIME type (e.g. "text/html"), a file name
-// extension or an alias like "zsh". Ref:
-// https://pkg.go.dev/github.com/alecthomas/chroma/v2#LexerRegistry.Get
+// Read and highlight some text using Chroma:
+// https://github.com/alecthomas/chroma
 //
 // Returns nil with no error if highlighting would be a no-op.
-func highlight(text string, format string, style chroma.Style, formatter chroma.Formatter) (*string, error) {
-	lexer := pickLexer(format)
+func highlight(text string, style chroma.Style, formatter chroma.Formatter, lexer chroma.Lexer) (*string, error) {
 	if lexer == nil {
 		// No highlighter available for this file type
 		return nil, nil

--- a/m/highlight.go
+++ b/m/highlight.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/alecthomas/chroma/v2"
-	"github.com/alecthomas/chroma/v2/lexers"
 )
 
 // Read and highlight some text using Chroma:
@@ -52,24 +51,4 @@ func highlight(text string, style chroma.Style, formatter chroma.Formatter, lexe
 	trimmed := strings.TrimSuffix(highlighted, sgrReset)
 
 	return &trimmed, nil
-}
-
-// Pick a lexer for the given filename and format.
-//
-// The format can be a filename, a MIME type (e.g. "text/html"), a file name
-// extension or an alias like "zsh". Ref:
-// https://pkg.go.dev/github.com/alecthomas/chroma/v2#LexerRegistry.Get
-func pickLexer(format string) chroma.Lexer {
-	byFileName := lexers.Match(format)
-	if byFileName != nil {
-		return byFileName
-	}
-
-	byMimeType := lexers.MatchMimeType(format)
-	if byMimeType != nil {
-		return byMimeType
-	}
-
-	// Use Chroma's built-in lexer picker
-	return lexers.Get(format)
 }

--- a/m/highlight.go
+++ b/m/highlight.go
@@ -10,6 +10,8 @@ import (
 // Read and highlight some text using Chroma:
 // https://github.com/alecthomas/chroma
 //
+// If lexer is nil no highlighting will be performed.
+//
 // Returns nil with no error if highlighting would be a no-op.
 func highlight(text string, style chroma.Style, formatter chroma.Formatter, lexer chroma.Lexer) (*string, error) {
 	if lexer == nil {

--- a/m/highlight.go
+++ b/m/highlight.go
@@ -8,11 +8,6 @@ import (
 	"github.com/alecthomas/chroma/v2/lexers"
 )
 
-// Files larger than this won't be highlighted
-//
-//revive:disable-next-line:var-naming
-const MAX_HIGHLIGHT_SIZE int64 = 1024 * 1024
-
 // Read and highlight some text using Chroma:
 // https://github.com/alecthomas/chroma
 //

--- a/m/pager_test.go
+++ b/m/pager_test.go
@@ -607,10 +607,15 @@ func benchmarkSearch(b *testing.B, highlighted bool) {
 		panic("Getting current filename failed")
 	}
 
+	sourceBytes, err := os.ReadFile(sourceFilename)
+	if err != nil {
+		panic(err)
+	}
+	fileContents := string(sourceBytes)
+
 	// Read one copy of the example input
-	var fileContents string
 	if highlighted {
-		highlightedSourceCode, err := highlight(sourceFilename, true, *styles.Get("native"), formatters.TTY16m)
+		highlightedSourceCode, err := highlight(fileContents, sourceFilename, *styles.Get("native"), formatters.TTY16m)
 		if err != nil {
 			panic(err)
 		}
@@ -618,12 +623,6 @@ func benchmarkSearch(b *testing.B, highlighted bool) {
 			panic("Highlighting didn't want to, returned nil")
 		}
 		fileContents = *highlightedSourceCode
-	} else {
-		sourceBytes, err := os.ReadFile(sourceFilename)
-		if err != nil {
-			panic(err)
-		}
-		fileContents = string(sourceBytes)
 	}
 
 	// Duplicate data N times

--- a/m/pager_test.go
+++ b/m/pager_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/alecthomas/chroma/v2/formatters"
+	"github.com/alecthomas/chroma/v2/lexers"
 	"github.com/alecthomas/chroma/v2/styles"
 	"github.com/google/go-cmp/cmp"
 	"github.com/walles/moar/twin"
@@ -615,7 +616,7 @@ func benchmarkSearch(b *testing.B, highlighted bool) {
 
 	// Read one copy of the example input
 	if highlighted {
-		highlightedSourceCode, err := highlight(fileContents, sourceFilename, *styles.Get("native"), formatters.TTY16m)
+		highlightedSourceCode, err := highlight(fileContents, *styles.Get("native"), formatters.TTY16m, lexers.Get("go"))
 		if err != nil {
 			panic(err)
 		}

--- a/m/pager_test.go
+++ b/m/pager_test.go
@@ -166,7 +166,7 @@ func TestCodeHighlighting(t *testing.T) {
 		panic("Getting current filename failed")
 	}
 
-	reader, err := NewReaderFromFilename(filename, *styles.Get("native"), formatters.TTY16m)
+	reader, err := NewReaderFromFilename(filename, *styles.Get("native"), formatters.TTY16m, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/m/reader.go
+++ b/m/reader.go
@@ -450,7 +450,7 @@ func NewReaderFromFilename(filename string, style chroma.Style, formatter chroma
 }
 
 func (reader *Reader) StartHighlightingFromFile(filename string, style chroma.Style, formatter chroma.Formatter, lexer chroma.Lexer) {
-	fileInfo, err := os.Stat(*reader.name)
+	fileInfo, err := os.Stat(filename)
 	if err != nil {
 		log.Warn("Failed to stat file for highlighting: ", err)
 		return
@@ -471,7 +471,7 @@ func (reader *Reader) StartHighlightingFromFile(filename string, style chroma.St
 			log.Trace("Highlighting done")
 		}()
 
-		fileBytes, err := os.ReadFile(*reader.name)
+		fileBytes, err := os.ReadFile(filename)
 		if err != nil {
 			log.Warn("Failed to read file for highlighting: ", err)
 			return
@@ -479,7 +479,7 @@ func (reader *Reader) StartHighlightingFromFile(filename string, style chroma.St
 
 		if lexer == nil {
 			// Try auto detecting by filename
-			lexer = lexers.Match(*reader.name)
+			lexer = lexers.Match(filename)
 		}
 
 		highlighted, err := highlight(string(fileBytes), style, formatter, lexer)

--- a/m/reader.go
+++ b/m/reader.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/chroma/v2"
+	"github.com/alecthomas/chroma/v2/lexers"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -412,6 +413,8 @@ func countLines(filename string) (uint64, error) {
 
 // NewReaderFromFilename creates a new file reader.
 //
+// If lexer is nil it will be determined from the input file name.
+//
 // The Reader will try to uncompress various compressed file format, and also
 // apply highlighting to the file using Chroma:
 // https://github.com/alecthomas/chroma
@@ -472,6 +475,11 @@ func (reader *Reader) StartHighlightingFromFile(filename string, style chroma.St
 		if err != nil {
 			log.Warn("Failed to read file for highlighting: ", err)
 			return
+		}
+
+		if lexer == nil {
+			// Try auto detecting by filename
+			lexer = lexers.Match(*reader.name)
 		}
 
 		highlighted, err := highlight(string(fileBytes), style, formatter, lexer)

--- a/m/reader_test.go
+++ b/m/reader_test.go
@@ -171,7 +171,7 @@ func TestGetLines(t *testing.T) {
 			}
 		}
 
-		reader, err := NewReaderFromFilename(file, *styles.Get("native"), formatters.TTY16m)
+		reader, err := NewReaderFromFilename(file, *styles.Get("native"), formatters.TTY16m, nil)
 		if err != nil {
 			t.Errorf("Error opening file <%s>: %s", file, err.Error())
 			continue
@@ -221,7 +221,7 @@ func testHighlightingLineCount(t *testing.T, filenameWithPath string) {
 	}
 
 	// Then load the same file using one of our Readers
-	reader, err := NewReaderFromFilename(filenameWithPath, *styles.Get("native"), formatters.TTY16m)
+	reader, err := NewReaderFromFilename(filenameWithPath, *styles.Get("native"), formatters.TTY16m, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -236,7 +236,7 @@ func testHighlightingLineCount(t *testing.T, filenameWithPath string) {
 
 func TestGetLongLine(t *testing.T) {
 	file := "../sample-files/very-long-line.txt"
-	reader, err := NewReaderFromFilename(file, *styles.Get("native"), formatters.TTY16m)
+	reader, err := NewReaderFromFilename(file, *styles.Get("native"), formatters.TTY16m, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -286,7 +286,7 @@ func TestStatusText(t *testing.T) {
 	testStatusText(t, 1, 1, 1, "1 line  100%")
 
 	// Test with filename
-	testMe, err := NewReaderFromFilename(getSamplesDir()+"/empty", *styles.Get("native"), formatters.TTY16m)
+	testMe, err := NewReaderFromFilename(getSamplesDir()+"/empty", *styles.Get("native"), formatters.TTY16m, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -301,7 +301,7 @@ func TestStatusText(t *testing.T) {
 
 func testCompressedFile(t *testing.T, filename string) {
 	filenameWithPath := getSamplesDir() + "/" + filename
-	reader, e := NewReaderFromFilename(filenameWithPath, *styles.Get("native"), formatters.TTY16m)
+	reader, e := NewReaderFromFilename(filenameWithPath, *styles.Get("native"), formatters.TTY16m, nil)
 	if e != nil {
 		t.Errorf("Error opening file <%s>: %s", filenameWithPath, e.Error())
 		panic(e)
@@ -374,7 +374,7 @@ func BenchmarkReaderDone(b *testing.B) {
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		// This is our longest .go file
-		readMe, err := NewReaderFromFilename(filename, *styles.Get("native"), formatters.TTY16m)
+		readMe, err := NewReaderFromFilename(filename, *styles.Get("native"), formatters.TTY16m, nil)
 		if err != nil {
 			panic(err)
 		}
@@ -424,7 +424,7 @@ func BenchmarkReadLargeFile(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		readMe, err := NewReaderFromFilename(largeFileName, *styles.Get("native"), formatters.TTY16m)
+		readMe, err := NewReaderFromFilename(largeFileName, *styles.Get("native"), formatters.TTY16m, nil)
 		if err != nil {
 			panic(err)
 		}

--- a/moar.1
+++ b/moar.1
@@ -45,6 +45,12 @@ Print debug logs after exiting, less verbose than
 Scrolls automatically to follow piped input, just like
 .B tail \-f
 .TP
+\fB\-\-lang\fR=string
+Used for highlighting.
+Without this flag highlighting is based on the input file name.
+Valid values are MIME types like \fBtext/x-markdown\fP, file extensions like \fBmd\fP or language names like \fBmarkdown\fP.
+For the source of truth on what is supported exactly, look in https://github.com/alecthomas/chroma/tree/master/lexers/embedded or its parent directory.
+.TP
 \fB\-\-mousemode\fR={\fBauto\fR | \fBselect\fR | \fBscroll\fR}
 Guarantee selecting text with the mouse works but maybe not mouse scrolling.
 Or guarantee mouse scrolling works but selecting text requiring extra effort.

--- a/moar.go
+++ b/moar.go
@@ -401,7 +401,7 @@ func main() {
 		"Highlighting style from https://xyproto.github.io/splash/docs/longer/all.html", parseStyleOption)
 	lexer := flagSetFunc(flagSet,
 		"lang", nil,
-		"Input file language for highlighting. Mime type or file extension (\"html\"). Defaults to auto detecting by filename.", parseLexerOption)
+		"File contents, used for highlighting. Mime type or file extension (\"html\"). Default is to guess by filename.", parseLexerOption)
 
 	defaultFormatter, err := parseColorsOption("auto")
 	if err != nil {

--- a/moar.go
+++ b/moar.go
@@ -170,8 +170,7 @@ func parseLexerOption(lexerOption string) (chroma.Lexer, error) {
 	}
 
 	return nil, fmt.Errorf(
-		"Unsupported language %s, look here form inspiration: https://github.com/alecthomas/chroma/tree/master/lexers/embedded",
-		lexerOption,
+		"Look here for inspiration: https://github.com/alecthomas/chroma/tree/master/lexers/embedded",
 	)
 }
 
@@ -220,7 +219,7 @@ func parseStatusBarStyle(styleOption string) (m.StatusBarOption, error) {
 		return m.STATUSBAR_STYLE_BOLD, nil
 	}
 
-	return 0, fmt.Errorf("good ones are inverse, plain and bold")
+	return 0, fmt.Errorf("Good ones are inverse, plain and bold")
 }
 
 func parseUnprintableStyle(styleOption string) (m.UnprintableStyle, error) {
@@ -252,7 +251,7 @@ func parseShiftAmount(shiftAmount string) (uint, error) {
 	}
 
 	if value < 1 {
-		return 0, fmt.Errorf("Shift amount must be at least 1, was %d", value)
+		return 0, fmt.Errorf("Shift amount must be at least 1")
 	}
 
 	// Let's add an upper bound as well if / when requested

--- a/moar.go
+++ b/moar.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/formatters"
+	"github.com/alecthomas/chroma/v2/lexers"
 	"github.com/alecthomas/chroma/v2/styles"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/term"
@@ -154,6 +155,24 @@ func printProblemsHeader() {
 	fmt.Fprintln(os.Stderr, "GOARCH  :", runtime.GOARCH)
 	fmt.Fprintln(os.Stderr, "Compiler:", runtime.Compiler)
 	fmt.Fprintln(os.Stderr, "NumCPU  :", runtime.NumCPU())
+}
+
+func parseLexerOption(lexerOption string) (chroma.Lexer, error) {
+	byMimeType := lexers.MatchMimeType(lexerOption)
+	if byMimeType != nil {
+		return byMimeType, nil
+	}
+
+	// Use Chroma's built-in fuzzy lexer picker
+	lexer := lexers.Get(lexerOption)
+	if lexer != nil {
+		return lexer, nil
+	}
+
+	return nil, fmt.Errorf(
+		"Unsupported language %s, look here form inspiration: https://github.com/alecthomas/chroma/tree/master/lexers/embedded",
+		lexerOption,
+	)
 }
 
 func parseStyleOption(styleOption string) (chroma.Style, error) {
@@ -381,6 +400,9 @@ func main() {
 	style := flagSetFunc(flagSet,
 		"style", *styles.Registry["native"],
 		"Highlighting style from https://xyproto.github.io/splash/docs/longer/all.html", parseStyleOption)
+	lexer := flagSetFunc(flagSet,
+		"lang", nil,
+		"Input file language for highlighting. Mime type or file extension (\"html\"). Defaults to auto detecting by filename.", parseLexerOption)
 
 	defaultFormatter, err := parseColorsOption("auto")
 	if err != nil {
@@ -527,7 +549,7 @@ func main() {
 		reader = m.NewReaderFromStream("", os.Stdin)
 	} else {
 		// Display the input file contents
-		reader, err = m.NewReaderFromFilename(*inputFilename, *style, formatter)
+		reader, err = m.NewReaderFromFilename(*inputFilename, *style, formatter, *lexer)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
 			os.Exit(1)


### PR DESCRIPTION
Works only for files.

Fixes #178.