### PR TITLE
Adapt theme to terminal background

### DIFF
--- a/m/pager.go
+++ b/m/pager.go
@@ -442,6 +442,9 @@ func (p *Pager) StartPaging(screen twin.Screen, chromaStyle *chroma.Style, chrom
 		case eventSpinnerUpdate:
 			spinner = event.spinner
 
+		case twin.EventTerminalBackgroundDetected:
+			// Do nothing, we don't care about background color updates
+
 		default:
 			log.Warnf("Unhandled event type: %v", event)
 		}

--- a/m/reader.go
+++ b/m/reader.go
@@ -171,8 +171,7 @@ func (reader *Reader) readStream(stream io.Reader, originalFileName *string, onD
 		onDone()
 	}
 
-	t1 := time.Now()
-	log.Debug("Stream read in ", t1.Sub(t0))
+	log.Debug("Stream read in ", time.Since(t0))
 }
 
 // NewReaderFromStream creates a new stream reader

--- a/m/reader.go
+++ b/m/reader.go
@@ -333,7 +333,7 @@ func countLines(filename string) (uint64, error) {
 	if count == 0 {
 		log.Debug("Counted ", count, " lines in ", t1.Sub(t0))
 	} else {
-		log.Debug("Counted ", count, " lines in ", t1.Sub(t0), " at ", (t1.Sub(t0))/time.Duration(count), "/line")
+		log.Debug("Counted ", count, " lines in ", t1.Sub(t0), " at ", t1.Sub(t0)/time.Duration(count), "/line")
 	}
 	return count, nil
 }

--- a/m/reader.go
+++ b/m/reader.go
@@ -110,7 +110,7 @@ func (reader *Reader) readStream(stream io.Reader, originalFileName *string, onD
 
 	bufioReader := bufio.NewReader(stream)
 	completeLine := make([]byte, 0)
-	t0 := time.Now().UnixNano()
+	t0 := time.Now()
 	for {
 		keepReadingLine := true
 		eof := false
@@ -171,9 +171,8 @@ func (reader *Reader) readStream(stream io.Reader, originalFileName *string, onD
 		onDone()
 	}
 
-	t1 := time.Now().UnixNano()
-	dtNanos := t1 - t0
-	log.Debug("Stream read in ", dtNanos/1_000_000, "ms")
+	t1 := time.Now()
+	log.Debug("Stream read in ", t1.Sub(t0))
 }
 
 // NewReaderFromStream creates a new stream reader
@@ -307,7 +306,7 @@ func countLines(filename string) (uint64, error) {
 	}()
 
 	var count uint64
-	t0 := time.Now().UnixNano()
+	t0 := time.Now()
 	buf := make([]byte, bufio.MaxScanTokenSize)
 	lastReadEndsInNewline := true
 	for {
@@ -331,12 +330,11 @@ func countLines(filename string) (uint64, error) {
 		count++
 	}
 
-	t1 := time.Now().UnixNano()
-	dtNanos := t1 - t0
+	t1 := time.Now()
 	if count == 0 {
-		log.Debug("Counted ", count, " lines in 0ms")
+		log.Debug("Counted ", count, " lines in ", t1.Sub(t0))
 	} else {
-		log.Debug("Counted ", count, " lines in ", dtNanos/1_000_000, "ms at ", dtNanos/int64(count), "ns/line")
+		log.Debug("Counted ", count, " lines in ", t1.Sub(t0), " at ", (t1.Sub(t0))/time.Duration(count), "/line")
 	}
 	return count, nil
 }

--- a/moar.go
+++ b/moar.go
@@ -648,21 +648,21 @@ func decodeStyleOption(styleOption **chroma.Style) chroma.Style {
 	response = strings.TrimSuffix(response, suffix)
 
 	// response is now "RRRR/GGGG/BBBB"
-	red, err := strconv.ParseUint(response[0:4], 16, 8)
+	red, err := strconv.ParseUint(response[0:4], 16, 16)
 	if err != nil {
-		log.Debug("Failed parsing red in bg color response from terminal: ", string(responseBytes))
+		log.Debug("Failed parsing red in bg color response from terminal: ", string(responseBytes), ": ", err)
 		return *styles.Get("native")
 	}
 
-	green, err := strconv.ParseUint(response[5:9], 16, 8)
+	green, err := strconv.ParseUint(response[5:9], 16, 16)
 	if err != nil {
-		log.Debug("Failed parsing green in bg color response from terminal: ", string(responseBytes))
+		log.Debug("Failed parsing green in bg color response from terminal: ", string(responseBytes), ": ", err)
 		return *styles.Get("native")
 	}
 
-	blue, err := strconv.ParseUint(response[10:14], 16, 8)
+	blue, err := strconv.ParseUint(response[10:14], 16, 16)
 	if err != nil {
-		log.Debug("Failed parsing blue in bg color response from terminal: ", string(responseBytes))
+		log.Debug("Failed parsing blue in bg color response from terminal: ", string(responseBytes), ": ", err)
 		return *styles.Get("native")
 	}
 

--- a/moar.go
+++ b/moar.go
@@ -593,7 +593,7 @@ func main() {
 			}
 
 		case <-time.After(5 * time.Millisecond):
-			log.Debug("Terminal background color still not detected after ", time.Since(t0))
+			log.Debug("Terminal background color still not detected after ", time.Since(t0), ", giving up")
 		}
 	} else {
 		style = **styleOption

--- a/moar.go
+++ b/moar.go
@@ -181,14 +181,14 @@ func parseLexerOption(lexerOption string) (chroma.Lexer, error) {
 	)
 }
 
-func parseStyleOption(styleOption string) (chroma.Style, error) {
+func parseStyleOption(styleOption string) (*chroma.Style, error) {
 	style, ok := styles.Registry[styleOption]
 	if !ok {
-		return *styles.Fallback, fmt.Errorf(
+		return &chroma.Style{}, fmt.Errorf(
 			"Pick a style from here: https://xyproto.github.io/splash/docs/longer/all.html")
 	}
 
-	return *style, nil
+	return style, nil
 }
 
 func parseColorsOption(colorsOption string) (twin.ColorType, error) {
@@ -404,8 +404,8 @@ func main() {
 
 	wrap := flagSet.Bool("wrap", false, "Wrap long lines")
 	follow := flagSet.Bool("follow", false, "Follow piped input just like \"tail -f\"")
-	style := flagSetFunc(flagSet,
-		"style", *styles.Registry["native"],
+	styleOption := flagSetFunc(flagSet,
+		"style", nil,
 		"Highlighting style from https://xyproto.github.io/splash/docs/longer/all.html", parseStyleOption)
 	lexer := flagSetFunc(flagSet,
 		"lang", nil,
@@ -558,6 +558,8 @@ func main() {
 		formatter = formatters.TTY16m
 	}
 
+	style := decodeStyleOption(styleOption)
+
 	var reader *m.Reader
 	if stdinIsRedirected {
 		// Display input pipe contents
@@ -590,6 +592,14 @@ func main() {
 	}
 
 	startPaging(pager, screen, style, &formatter)
+}
+
+func decodeStyleOption(styleOption **chroma.Style) *chroma.Style {
+	if *styleOption != nil {
+		return *styleOption
+	}
+
+	return styles.Get("native")
 }
 
 // Define a generic flag with specified name, default value, and usage string.

--- a/moar.go
+++ b/moar.go
@@ -601,6 +601,19 @@ func decodeStyleOption(styleOption **chroma.Style) chroma.Style {
 		return **styleOption
 	}
 
+	// Prep for querying the terminal background color
+	oldTerminalState, err := term.MakeRaw(int(os.Stdout.Fd()))
+	if err != nil {
+		log.Debug("Failed setting up terminal for bg color detection: ", err)
+		return *styles.Get("native")
+	}
+	defer func() {
+		err := term.Restore(int(os.Stdout.Fd()), oldTerminalState)
+		if err != nil {
+			log.Error("Failed restoring terminal state: ", err)
+		}
+	}()
+
 	// Ref: https://stackoverflow.com/questions/2507337/how-to-determine-a-terminals-background-color
 	fmt.Println("\x1b]11;?\x07")
 

--- a/moar.go
+++ b/moar.go
@@ -25,6 +25,16 @@ import (
 	"github.com/walles/moar/twin"
 )
 
+const defaultDarkTheme = "native"
+
+// I decided on a light theme by doing this:
+//
+//	wc -l ../chroma/styles/*.xml|sort|cut -d/ -f4|grep xml|xargs -I XXX grep -Hi background ../chroma/styles/XXX
+//
+// Then I picked tango because it has a lot of lines, a bright background
+// and I like the looks of it.
+const defaultLightTheme = "tango"
+
 var versionString = "Should be set when building, please use build.sh to build"
 
 func printUsageEnvVar(output io.Writer, envVarName string, description string) {
@@ -605,7 +615,7 @@ func decodeStyleOption(styleOption **chroma.Style) chroma.Style {
 	oldTerminalState, err := term.MakeRaw(int(os.Stdout.Fd()))
 	if err != nil {
 		log.Debug("Failed setting up terminal for bg color detection: ", err)
-		return *styles.Get("native")
+		return *styles.Get(defaultDarkTheme)
 	}
 	defer func() {
 		err := term.Restore(int(os.Stdout.Fd()), oldTerminalState)
@@ -631,19 +641,19 @@ func decodeStyleOption(styleOption **chroma.Style) chroma.Style {
 	}
 	if n != len(sampleResponse) {
 		log.Debug("Got unexpected length bg color response from terminal: ", string(responseBytes))
-		return *styles.Get("native")
+		return *styles.Get(defaultDarkTheme)
 	}
 
 	response := string(responseBytes)
 	if !strings.HasPrefix(response, prefix) {
 		log.Debug("Got unexpected prefix in bg color response from terminal: ", string(responseBytes))
-		return *styles.Get("native")
+		return *styles.Get(defaultDarkTheme)
 	}
 	response = strings.TrimPrefix(response, prefix)
 
 	if !strings.HasSuffix(response, suffix) {
 		log.Debug("Got unexpected suffix in bg color response from terminal: ", string(responseBytes))
-		return *styles.Get("native")
+		return *styles.Get(defaultDarkTheme)
 	}
 	response = strings.TrimSuffix(response, suffix)
 
@@ -651,19 +661,19 @@ func decodeStyleOption(styleOption **chroma.Style) chroma.Style {
 	red, err := strconv.ParseUint(response[0:4], 16, 16)
 	if err != nil {
 		log.Debug("Failed parsing red in bg color response from terminal: ", string(responseBytes), ": ", err)
-		return *styles.Get("native")
+		return *styles.Get(defaultDarkTheme)
 	}
 
 	green, err := strconv.ParseUint(response[5:9], 16, 16)
 	if err != nil {
 		log.Debug("Failed parsing green in bg color response from terminal: ", string(responseBytes), ": ", err)
-		return *styles.Get("native")
+		return *styles.Get(defaultDarkTheme)
 	}
 
 	blue, err := strconv.ParseUint(response[10:14], 16, 16)
 	if err != nil {
 		log.Debug("Failed parsing blue in bg color response from terminal: ", string(responseBytes), ": ", err)
-		return *styles.Get("native")
+		return *styles.Get(defaultDarkTheme)
 	}
 
 	color := twin.NewColor24Bit(uint8(red/256), uint8(green/256), uint8(blue/256))
@@ -674,16 +684,10 @@ func decodeStyleOption(styleOption **chroma.Style) chroma.Style {
 	darkTheme := distanceToBlack < distanceToWhite
 
 	if darkTheme {
-		return *styles.Get("native")
+		return *styles.Get(defaultDarkTheme)
 	}
 
-	// I decided on a light theme by doing this:
-	//
-	//   wc -l ../chroma/styles/*.xml|sort|cut -d/ -f4|grep xml|xargs -I XXX grep -Hi background ../chroma/styles/XXX
-	//
-	// Then I picked tango because it has a lot of lines, a bright background
-	// and I like the looks of it.
-	return *styles.Get("tango")
+	return *styles.Get(defaultLightTheme)
 }
 
 // Define a generic flag with specified name, default value, and usage string.

--- a/moar.go
+++ b/moar.go
@@ -611,6 +611,8 @@ func decodeStyleOption(styleOption **chroma.Style) chroma.Style {
 		return **styleOption
 	}
 
+	t0 := time.Now()
+
 	// Prep for querying the terminal background color
 	oldTerminalState, err := term.MakeRaw(int(os.Stdout.Fd()))
 	if err != nil {
@@ -675,6 +677,9 @@ func decodeStyleOption(styleOption **chroma.Style) chroma.Style {
 		log.Debug("Failed parsing blue in bg color response from terminal: ", string(responseBytes), ": ", err)
 		return *styles.Get(defaultDarkTheme)
 	}
+
+	t1 := time.Now()
+	log.Debug("Terminal background color detection took ", t1.Sub(t0))
 
 	color := twin.NewColor24Bit(uint8(red/256), uint8(green/256), uint8(blue/256))
 	log.Debug("Terminal background color detected: ", color)

--- a/moar.go
+++ b/moar.go
@@ -667,6 +667,8 @@ func decodeStyleOption(styleOption **chroma.Style) chroma.Style {
 	}
 
 	color := twin.NewColor24Bit(uint8(red/256), uint8(green/256), uint8(blue/256))
+	log.Debug("Terminal background color detected: ", color)
+
 	distanceToBlack := color.Distance(twin.NewColor24Bit(0, 0, 0))
 	distanceToWhite := color.Distance(twin.NewColor24Bit(255, 255, 255))
 	darkTheme := distanceToBlack < distanceToWhite

--- a/twin/events.go
+++ b/twin/events.go
@@ -12,6 +12,11 @@ type EventKeyCode struct {
 	keyCode KeyCode
 }
 
+type EventTerminalBackgroundDetected struct {
+	// Terminal background color
+	Color Color
+}
+
 type MouseButtonMask uint16
 
 const (

--- a/twin/fake-screen.go
+++ b/twin/fake-screen.go
@@ -72,6 +72,11 @@ func (screen *FakeScreen) Size() (width int, height int) {
 	return screen.width, screen.height
 }
 
+func (screen *FakeScreen) TerminalBackgroundColor() *Color {
+	// THe fake screen has an unknown background color
+	return nil
+}
+
 func (screen *FakeScreen) ShowCursorAt(_ int, _ int) {
 	// This method intentionally left blank
 }

--- a/twin/fake-screen.go
+++ b/twin/fake-screen.go
@@ -72,11 +72,6 @@ func (screen *FakeScreen) Size() (width int, height int) {
 	return screen.width, screen.height
 }
 
-func (screen *FakeScreen) TerminalBackgroundColor() *Color {
-	// THe fake screen has an unknown background color
-	return nil
-}
-
 func (screen *FakeScreen) ShowCursorAt(_ int, _ int) {
 	// This method intentionally left blank
 }

--- a/twin/screen.go
+++ b/twin/screen.go
@@ -567,7 +567,6 @@ func parseTerminalBgColorResponse(responseBytes []byte) *Color {
 	}
 
 	color := NewColor24Bit(uint8(red/256), uint8(green/256), uint8(blue/256))
-	log.Debug("Terminal background color detected: ", color)
 
 	return &color
 }


### PR DESCRIPTION
Ask the terminal for its background color.

If the background color is bright, use the Tango style. If the background color is dark, use Native.

<img width="577" alt="dark-native" src="https://github.com/walles/moar/assets/158201/18813d25-f437-4d8d-973b-c359169438da">

<img width="577" alt="bright-tango" src="https://github.com/walles/moar/assets/158201/2d5a0e27-b8e7-4953-8da1-75123b603a7f">
