### PR TITLE
Use the "select" mouse mode on Rio

### DIFF
--- a/twin/screen.go
+++ b/twin/screen.go
@@ -286,6 +286,11 @@ func terminalHasArrowKeysEmulation() bool {
 		return true
 	}
 
+	// Rio, tested on macOS 14.3, January 27th, 2024
+	if os.Getenv("TERM_PROGRAM") == "rio" {
+		return true
+	}
+
 	return false
 }
 


### PR DESCRIPTION
This adds [Rio](https://github.com/raphamorim/rio) to the list of tested terminals with working "select" mouse mode.