### PR TITLE
Use 24-bit color if `COLORTERM=truecolor` is in the environment

### DIFF
--- a/moar.go
+++ b/moar.go
@@ -304,7 +304,7 @@ func parseStyleOption(styleOption string) (*chroma.Style, error) {
 func parseColorsOption(colorsOption string) (twin.ColorType, error) {
 	if strings.ToLower(colorsOption) == "auto" {
 		colorsOption = "16M"
-		if strings.Contains(os.Getenv("TERM"), "256") {
+		if os.Getenv("COLORTERM") != "truecolor" && strings.Contains(os.Getenv("TERM"), "256") {
 			// Covers "xterm-256color" as used by the macOS Terminal
 			colorsOption = "256"
 		}

--- a/twin/screen.go
+++ b/twin/screen.go
@@ -113,7 +113,7 @@ func NewScreen() (Screen, error) {
 
 func NewScreenWithMouseMode(mouseMode MouseMode) (Screen, error) {
 	terminalColorCount := ColorType24bit
-	if strings.Contains(os.Getenv("TERM"), "256") {
+	if os.Getenv("COLORTERM") != "truecolor" && strings.Contains(os.Getenv("TERM"), "256") {
 		// Covers "xterm-256color" as used by the macOS Terminal
 		terminalColorCount = ColorType256
 	}


### PR DESCRIPTION
Setting the `COLORTERM` environment variable to `truecolor` is used to indicate 24-bit color support. It's set by default in terminal emulators such as [Alacritty](https://github.com/alacritty/alacritty/blob/117719b3216d60ddde4096d9b2bdccecfd214c42/alacritty_terminal/src/tty/mod.rs#L95), [kitty](https://github.com/kovidgoyal/kitty/blob/5a418a8cd6dd8bbba14a4fed9717469ecc43718e/kitty/child.py#L233), [iTerm2](https://github.com/gnachman/iTerm2/blob/faa6d7519217ffc47b994bbca1b77ed9b6db889a/sources/PTYSession.m#L2622), [Hyper](https://github.com/vercel/hyper/blob/1323098091f58843deb1a546091ab3a460b8091f/app/session.ts#L127), [Tabby](https://github.com/Eugeny/tabby/blob/5d8ff72850ec6e147e5ab5c6571d834d159e94b1/tabby-local/src/session.ts#L73), [WezTerm](https://github.com/wez/wezterm/blob/a7d9cfd25f992c94b8cf03ba41711047c72da87d/config/src/config.rs#L1541).