### PR TITLE
Fancy shutdown

### DIFF
--- a/twin/screen-setup-windows.go
+++ b/twin/screen-setup-windows.go
@@ -19,6 +19,11 @@ type interruptableReaderImpl struct {
 	shutdownRequested atomic.Bool
 }
 
+// NOTE: To work properly, this Read() should return immediately after somebody
+// calls Interrupt(), *without first reading any bytes from the base reader*.
+//
+// This implementation doesn't do that. If you want to fix this, the not-Windows
+// implementation in screen-setup.go may or may not work as inspiration.
 func (r *interruptableReaderImpl) Read(p []byte) (n int, err error) {
 	if r.shutdownRequested.Load() {
 		err = io.EOF

--- a/twin/screen-setup-windows.go
+++ b/twin/screen-setup-windows.go
@@ -15,7 +15,7 @@ import (
 )
 
 type interruptableReaderImpl struct {
-	base              io.Reader
+	base              *os.File
 	shutdownRequested atomic.Bool
 }
 
@@ -45,8 +45,8 @@ func (r *interruptableReaderImpl) Interrupt() {
 	r.shutdownRequested.Store(true)
 }
 
-func newInterruptableReader(base io.Reader) interruptableReader {
-	return &interruptableReaderImpl{base: base}
+func newInterruptableReader(base *os.File) (interruptableReader, error) {
+	return &interruptableReaderImpl{base: base}, nil
 }
 
 func (screen *UnixScreen) setupSigwinchNotification() {

--- a/twin/screen-setup-windows.go
+++ b/twin/screen-setup-windows.go
@@ -20,6 +20,11 @@ type interruptableReaderImpl struct {
 }
 
 func (r *interruptableReaderImpl) Read(p []byte) (n int, err error) {
+	if r.shutdownRequested.Load() {
+		err = io.EOF
+		return
+	}
+
 	n, err = r.base.Read(p)
 	if err != nil {
 		return

--- a/twin/screen.go
+++ b/twin/screen.go
@@ -136,7 +136,6 @@ func NewScreenWithMouseModeAndColorType(mouseMode MouseMode, terminalColorCount 
 
 	screen := UnixScreen{
 		terminalColorCount: terminalColorCount,
-		ttyInReader:        newInterruptableReader(),
 	}
 
 	// The number "80" here is from manual testing on my MacBook:
@@ -157,6 +156,7 @@ func NewScreenWithMouseModeAndColorType(mouseMode MouseMode, terminalColorCount 
 	if err != nil {
 		return nil, fmt.Errorf("problem setting up TTY: %w", err)
 	}
+	screen.ttyInReader = newInterruptableReader(screen.ttyIn)
 
 	screen.setAlternateScreenMode(true)
 

--- a/twin/screen.go
+++ b/twin/screen.go
@@ -156,7 +156,14 @@ func NewScreenWithMouseModeAndColorType(mouseMode MouseMode, terminalColorCount 
 	if err != nil {
 		return nil, fmt.Errorf("problem setting up TTY: %w", err)
 	}
-	screen.ttyInReader = newInterruptableReader(screen.ttyIn)
+	screen.ttyInReader, err = newInterruptableReader(screen.ttyIn)
+	if err != nil {
+		restoreErr := screen.restoreTtyInTtyOut()
+		if restoreErr != nil {
+			log.Warn("Problem restoring TTY state after failed interruptable reader setup: ", restoreErr)
+		}
+		return nil, fmt.Errorf("problem setting up TTY reader: %w", err)
+	}
 
 	screen.setAlternateScreenMode(true)
 


### PR DESCRIPTION
Do fancy shutdown on Unix.

If you...
* Are on Unix
* Press "v" to launch an editor
* Have a terminal editor configured (think `vi`, not VSCode)

Then, with this change in place, `moar` won't steal the first byte(s) of input from your editor any more, so pressing down arrow to begin with should just work immediately.

On Windows the interruptable-reader code is unchanged. If you want to implement fancy shutdown there as well look here:
https://github.com/walles/moar/blob/45480cf70209bdcbe1e38e61ce7d7571d6256fe1/twin/screen-setup-windows.go#L17-L55

Relates to #222.