### PR TITLE
Windows: Build tests separately

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -18,4 +18,9 @@ jobs:
           go-version-file: "go.mod"
 
       - run: go build
-      - run: go test -timeout 60s ./...
+
+      # Ref: https://github.com/golang/go/issues/15513#issuecomment-1883202920
+      - name: Build tests
+        run: go test -c -o /dev/null $(go list -f '{{if .TestGoFiles}}{{.ImportPath}}{{end}}' ./...)
+
+      - run: go test -timeout 30s ./...


### PR DESCRIPTION
Because building the tests is slow on Windows.
