### PR TITLE
Use module version when not built with script.

### DIFF
--- a/moar.go
+++ b/moar.go
@@ -525,9 +525,8 @@ func getVersion() string {
 	info, ok := debug.ReadBuildInfo()
 	if ok {
 		return info.Main.Version
-	} else {
-		return "Should be set when building, please use build.sh to build"
 	}
+	return "Should be set when building, please use build.sh to build"
 }
 
 // Can return a nil pager on --help or --version, or if pumping to stdout.

--- a/moar.go
+++ b/moar.go
@@ -523,7 +523,7 @@ func getVersion() string {
 		return versionString
 	}
 	info, ok := debug.ReadBuildInfo()
-	if ok {
+	if ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
 		return info.Main.Version
 	}
 	return "Should be set when building, please use build.sh to build"

--- a/moar.go
+++ b/moar.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
@@ -36,7 +37,7 @@ const defaultDarkTheme = "native"
 // and I like the looks of it.
 const defaultLightTheme = "tango"
 
-var versionString = "Should be set when building, please use build.sh to build"
+var versionString = ""
 
 func renderLessTermcapEnvVar(envVarName string, description string, colors twin.ColorCount) string {
 	value := os.Getenv(envVarName)
@@ -276,7 +277,7 @@ func printProblemsHeader() {
 	fmt.Fprintln(os.Stderr, "Please post the following report at <https://github.com/walles/moar/issues>,")
 	fmt.Fprintln(os.Stderr, "or e-mail it to johan.walles@gmail.com.")
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, "Version:", versionString)
+	fmt.Fprintln(os.Stderr, "Version:", getVersion())
 	fmt.Fprintln(os.Stderr, "LANG   :", os.Getenv("LANG"))
 	fmt.Fprintln(os.Stderr, "TERM   :", os.Getenv("TERM"))
 	fmt.Fprintln(os.Stderr, "MOAR   :", os.Getenv("MOAR"))
@@ -516,6 +517,19 @@ func noLineNumbersDefault() bool {
 	return false
 }
 
+// Return complete version when built with build.sh or fallback to module version (i.e. "go install")
+func getVersion() string {
+	if versionString != "" {
+		return versionString
+	}
+	info, ok := debug.ReadBuildInfo()
+	if ok {
+		return info.Main.Version
+	} else {
+		return "Should be set when building, please use build.sh to build"
+	}
+}
+
 // Can return a nil pager on --help or --version, or if pumping to stdout.
 func pagerFromArgs(
 	args []string,
@@ -608,7 +622,7 @@ func pagerFromArgs(
 	}
 
 	if *printVersion {
-		fmt.Println(versionString)
+		fmt.Println(getVersion())
 		return nil, nil, chroma.Style{}, nil, nil
 	}
 


### PR DESCRIPTION
I often install using `go install github.com/walles/moar@latest` and while one can use `go version -m <binary>` it bothers me not to have a working `moar --version`, this should fix it.

As [suggested to me on the Fediverse](https://f.lapo.it/display/6a1cc041-1066-d18b-7e0e-fcf286277536).