### PR TITLE
Add short forms for some flags

### DIFF
--- a/moar.go
+++ b/moar.go
@@ -334,16 +334,22 @@ func pagerFromArgs(
 	flagSet.SetOutput(io.Discard) // We want to do our own printing
 
 	printVersion := flagSet.Bool("version", false, "Prints the moar version number")
+	flagSet.BoolVar(printVersion, "V", false, "Prints the moar version number")
 	debug := flagSet.Bool("debug", false, "Print debug logs after exiting")
 	trace := flagSet.Bool("trace", false, "Print trace logs after exiting")
 
 	wrap := flagSet.Bool("wrap", false, "Wrap long lines")
+	flagSet.BoolVar(wrap, "w", false, "Wrap long lines")
 	follow := flagSet.Bool("follow", false, "Follow piped input just like \"tail -f\"")
+	flagSet.BoolVar(follow, "f", false, "Follow piped input just like \"tail -f\"")
 	styleOption := flagSetFunc(flagSet,
 		"style", nil,
 		"Highlighting `style` from https://xyproto.github.io/splash/docs/longer/all.html", parseStyleOption)
 	lexer := flagSetFunc(flagSet,
 		"lang", nil,
+		"File contents, used for highlighting. Mime type or file extension (\"html\"). Default is to guess by filename.", parseLexerOption)
+	flagSetFuncVar(flagSet,
+		lexer, "l", nil,
 		"File contents, used for highlighting. Mime type or file extension (\"html\"). Default is to guess by filename.", parseLexerOption)
 	terminalFg := flagSet.Bool("terminal-fg", false, "Use terminal foreground color rather than style foreground for plain text")
 
@@ -359,6 +365,7 @@ func pagerFromArgs(
 	reFormat := flagSet.Bool("reformat", false, "Reformat some input files (JSON)")
 	flagSet.Bool("no-reformat", true, "No effect, kept for compatibility. See --reformat")
 	quitIfOneScreen := flagSet.Bool("quit-if-one-screen", false, "Don't page if contents fits on one screen")
+	flagSet.BoolVar(quitIfOneScreen, "F", false, "Don't page if contents fits on one screen")
 	noClearOnExit := flagSet.Bool("no-clear-on-exit", false, "Retain screen contents when exiting moar")
 	statusBarStyle := flagSetFunc(flagSet, "statusbar", m.STATUSBAR_STYLE_INVERSE,
 		"Status bar `style`: inverse, plain or bold", parseStatusBarStyle)
@@ -642,18 +649,24 @@ func main() {
 // The return value is the address of a variable that stores the parsed value of
 // the flag.
 func flagSetFunc[T any](flagSet *flag.FlagSet, name string, defaultValue T, usage string, parser func(valueString string) (T, error)) *T {
-	parsed := defaultValue
+	var parsed T
+	flagSetFuncVar(flagSet, &parsed, name, defaultValue, usage, parser)
+	return &parsed
+}
+
+// Define a generic flag with specified name, default value, and usage string.
+// The parsed value of the flag will be written to the passed pointer.
+func flagSetFuncVar[T any](flagSet *flag.FlagSet, p *T, name string, defaultValue T, usage string, parser func(valueString string) (T, error)) {
+	*p = defaultValue
 
 	flagSet.Func(name, usage, func(valueString string) error {
 		parseResult, err := parser(valueString)
 		if err != nil {
 			return err
 		}
-		parsed = parseResult
+		*p = parseResult
 		return nil
 	})
-
-	return &parsed
 }
 
 func startPaging(pager *m.Pager, screen twin.Screen, chromaStyle *chroma.Style, chromaFormatter *chroma.Formatter) {

--- a/usage.go
+++ b/usage.go
@@ -15,6 +15,32 @@ import (
 	"github.com/walles/moar/twin"
 )
 
+const flags_usage = `      --colors value              Highlighting palette size: 8, 16, 256, 16M, auto
+      --debug                     Print debug logs after exiting
+  -f, --follow                    Follow piped input just like "tail -f"
+  -l, --lang value                File contents, used for highlighting. Mime type or extension ("html"). Default is to guess by filename.
+      --mousemode mode            Mouse mode: auto, select or scroll: https://github.com/walles/moar/blob/master/MOUSE.md
+      --no-clear-on-exit          Retain screen contents when exiting moar
+      --no-linenumbers            Hide line numbers on startup, press left arrow key to show
+      --no-reformat               No effect, kept for compatibility. See --reformat (default true)
+      --no-statusbar              Hide the status bar, toggle with '='
+  -F, --quit-if-one-screen        Don't page if contents fits on one screen
+      --reformat                  Reformat some input files (JSON)
+      --render-unprintable value  How unprintable characters are rendered: highlight or whitespace
+      --scroll-left-hint value    Shown when view can scroll left. One character with optional ANSI highlighting.
+      --scroll-right-hint value   Shown when view can scroll right. One character with optional ANSI highlighting.
+      --shift amount              Horizontal scroll amount >= 1, defaults to 16
+      --statusbar style           Status bar style: inverse, plain or bold
+      --style style               Highlighting style from https://xyproto.github.io/splash/docs/longer/all.html
+      --terminal-fg               Use terminal foreground color rather than style foreground for plain text
+      --trace                     Print trace logs after exiting
+  -w, --wrap                      Wrap long lines
+
+  +1234                           Immediately scroll to line 1234
+
+  -h, --help                      Show this help text
+  -V, --version                   Print the moar version number`
+
 func renderLessTermcapEnvVar(envVarName string, description string, colors twin.ColorCount) string {
 	value := os.Getenv(envVarName)
 	if len(value) == 0 {
@@ -187,10 +213,7 @@ func printUsage(flagSet *flag.FlagSet, colors twin.ColorCount) {
 	fmt.Println()
 	fmt.Println(heading("Options", colors))
 
-	flagSet.PrintDefaults()
-
-	fmt.Println("  +1234")
-	fmt.Println("    \tImmediately scroll to line 1234")
+	fmt.Println(flags_usage)
 }
 
 // If $PAGER isn't pointing to us, print a help text on how to set it.


### PR DESCRIPTION
The default `flags` package for go has fairly poor documentation regarding how to do short and long forms of flags. The simplest way to do this appears to be to define separate flags that write to the same pointer, and then override the help text so that they get shown together.

This PR currently defines:

* `-f` for `--follow`
* `-l` for `--lang`
* `-F` for `--quit-if-one-screen`
* `-w` for `--wrap`
* `-V` for `--version`
* `-h` for `--help` is automatically checked by the upstream package, but neither form was listed in the default help text
* Suggestions for further short flags or changed flags would be welcome

The overridden help text I made prints each flag, including `-h`/`--help`, on a single line, with short flags, long flags, and descriptions each being column-aligned. It also uses double-dashes for long flags, and while the ability to use single-dashes is needed for short-flag support, the default help text only using single-dashes was very confusing, at least to me.

Due to how the default `flags` package works, while the custom help text only shows single-dashes for short flags and double-dashes for long flags, the other way around will still be parsed and accepted. This comes with the perhaps surprising quirk that multiple short flags need to be separated by spaces, rather than being accepted as compound flags that all share a single-dash.

Being new to this project, I am uncertain regarding style choices and am willing to modify the way things are written to better fit the established code (for example: changing the help text from a large constant string into a sequence of `fmt.Println` statements). I am also willing to change the format of the help text if desired.

Resolves #98 