### PR TITLE
Add Alt-U shortcut to clear search highlight

### DIFF
--- a/m/pagermode-viewing.go
+++ b/m/pagermode-viewing.go
@@ -64,6 +64,10 @@ func (m PagerModeViewing) onKey(keyCode twin.KeyCode) {
 		p.scrollPosition = p.scrollPosition.NextLine(p.visibleHeight())
 		p.handleScrolledDown()
 
+	case twin.KeyAltU:
+		p.searchPattern = nil
+		p.searchString = ""
+
 	default:
 		log.Debugf("Unhandled key event %v", keyCode)
 	}

--- a/twin/keys.go
+++ b/twin/keys.go
@@ -18,6 +18,7 @@ const (
 	KeyAltDown
 	KeyAltRight
 	KeyAltLeft
+	KeyAltU
 
 	KeyHome
 	KeyEnd
@@ -61,6 +62,7 @@ var escapeSequenceToKeyCode = map[string]KeyCode{
 	"\x1b\x1b[B": KeyAltDown,  // Alt + down arrow
 	"\x1b\x1b[C": KeyAltRight, // Alt + right arrow
 	"\x1b\x1b[D": KeyAltLeft,  // Alt + left arrow
+	"\x1bu":      KeyAltU,
 
 	"\x1b[H":  KeyHome,
 	"\x1b[F":  KeyEnd,


### PR DESCRIPTION
Adds the Alt-U keybinding from `less` to clear highlights on searched text.