### PR TITLE
Fix handling of fragmented terminal background color responses

### DIFF
--- a/twin/screen.go
+++ b/twin/screen.go
@@ -437,13 +437,11 @@ func (screen *UnixScreen) mainLoop() {
 				}
 				continue
 			}
-			// Not valid
+
+			// Not valid, give up
+			expectingTerminalBackgroundColor = false
 			incompleteResponse = nil
 		}
-
-		// We only expect this on entry, it's requested right before we start
-		// the main loop in NewScreenWithMouseModeAndColorCount().
-		expectingTerminalBackgroundColor = false
 
 		if count > maxBytesRead {
 			maxBytesRead = count

--- a/twin/screen.go
+++ b/twin/screen.go
@@ -436,9 +436,8 @@ func (screen *UnixScreen) mainLoop() {
 					incompleteResponse = nil
 				}
 				continue
-			} else {
-				incompleteResponse = nil
 			}
+			incompleteResponse = nil
 		}
 
 		// We only expect this on entry, it's requested right before we start

--- a/twin/screen.go
+++ b/twin/screen.go
@@ -437,7 +437,9 @@ func (screen *UnixScreen) mainLoop() {
 				}
 				continue
 			}
+			// Not valid
 			incompleteResponse = nil
+			expectingTerminalBackgroundColor = false
 		}
 
 		// We only expect this on entry, it's requested right before we start
@@ -629,6 +631,7 @@ func parseTerminalBgColorResponse(responseBytes []byte) (*Color, bool) {
 
 	isComplete := strings.HasSuffix(response, suffix1) || strings.HasSuffix(response, suffix2)
 	if !isComplete && (len(responseBytes) < len(sampleResponse1) || len(responseBytes) < len(sampleResponse2)) {
+		log.Debug("Terminal bg color response received so far: ", response)
 		return nil, true // Incomplete but valid
 	}
 

--- a/twin/screen.go
+++ b/twin/screen.go
@@ -439,7 +439,6 @@ func (screen *UnixScreen) mainLoop() {
 			}
 			// Not valid
 			incompleteResponse = nil
-			expectingTerminalBackgroundColor = false
 		}
 
 		// We only expect this on entry, it's requested right before we start


### PR DESCRIPTION
This PR resolves #271.

**Key Changes:**  
1. **Response Buffering**  
   - Added `incompleteResponse` buffer to accumulate partial escape sequences  
   ```diff
   + var incompleteResponse []byte
   ```
2. **Enhanced Parsing Logic**  
   - Modified `parseTerminalBgColorResponse()` to return completion status:  
   ```diff
   - func parseTerminalBgColorResponse(...) *Color
   + func parseTerminalBgColorResponse(...) (*Color, bool)
   ```

**Verification:**  
Tested with Gruvbox Dark some shcemes, no accidental search mode activation observed:  

```
time="Feb 22 20:56:42.453124" level=debug msg="File is assumed to be uncompressed: /home/fesmoph/.condarc"
time="Feb 22 20:56:42.454905" level=debug msg="File is assumed to be uncompressed: /home/fesmoph/.condarc"
time="Feb 22 20:56:42.454928" level=debug msg="Counted 14 lines in 6.478µs at 462ns/line"
time="Feb 22 20:56:42.454941" level=info msg="Stream read in 8.163µs"
time="Feb 22 20:56:42.455058" level=info msg="ttyin terminal state: &{state:{termios:{Iflag:0 Oflag:4 Cflag:191 Lflag:2608 Line:0 Cc:[3 28 127 21 4 0 1 0 17 19 26 0 18 15 23 22 0 0 0] Ispeed:0 Ospeed:0}}}"
time="Feb 22 20:56:42.455066" level=info msg="ttyout terminal state: &{state:{termios:{Iflag:0 Oflag:4 Cflag:191 Lflag:2608 Line:0 Cc:[3 28 127 21 4 0 1 0 17 19 26 0 18 15 23 22 0 0 0] Ispeed:0 Ospeed:0}}}"
time="Feb 22 20:56:42.455098" level=info msg="No known terminal with arrow keys emulation detected, assuming mouse tracking is needed"
time="Feb 22 20:56:42.455107" level=info msg="Entering Twin main loop..."
time="Feb 22 20:56:42.456013" level=debug msg="Terminal background color detected as #282828 after 890.63µs"
time="Feb 22 20:56:42.456023" level=debug msg="Using style <native>"
time="Feb 22 20:56:42.456038" level=info msg="Pager starting"
time="Feb 22 20:56:42.456150" level=debug msg="No lexer set for highlighting"
time="Feb 22 20:56:42.456156" level=debug msg="highlightFromMemory() took 1.212662ms"
time="Feb 22 20:56:42.456158" level=debug msg="Tailing file /home/fesmoph/.condarc"
time="Feb 22 20:56:42.456774" level=info msg="Entering pager main loop..."
time="Feb 22 20:56:43.063147" level=trace msg="ttyin high watermark bumped to 1 bytes"
time="Feb 22 20:56:43.063314" level=trace msg="Handling rune event 'q'/0x0071..."
time="Feb 22 20:56:43.063419" level=info msg="ttyin read error, twin giving up: EOF"
```

This fix resolves my immediate issue but would benefit from maintainer review. Happy to adjust based on feedback.