### PR TITLE
feat: add `-search` flag to drop into search mode

### DIFF
--- a/m/pager.go
+++ b/m/pager.go
@@ -101,6 +101,8 @@ type Pager struct {
 	// Ref: https://github.com/walles/moar/issues/175
 	marks map[rune]scrollPosition
 
+	ShouldStartWithSearch bool
+
 	AfterExit func() error
 }
 
@@ -321,7 +323,11 @@ func (p *Pager) StartPaging(screen twin.Screen, chromaStyle *chroma.Style, chrom
 	styleUI(chromaStyle, chromaFormatter, p.StatusBarStyle, p.WithTerminalFg)
 
 	p.screen = screen
-	p.mode = PagerModeViewing{pager: p}
+	if p.ShouldStartWithSearch {
+		p.mode = PagerModeSearch{pager: p}
+	} else {
+		p.mode = PagerModeViewing{pager: p}
+	}
 	p.marks = make(map[rune]scrollPosition)
 
 	go func() {

--- a/m/pagermode-search.go
+++ b/m/pagermode-search.go
@@ -108,6 +108,8 @@ func removeLastChar(s string) string {
 
 func (m PagerModeSearch) onKey(key twin.KeyCode) {
 	switch key {
+	case twin.KeyCtrlD:
+		m.pager.Quit()
 	case twin.KeyEnter:
 		m.pager.mode = PagerModeViewing{pager: m.pager}
 

--- a/moar.go
+++ b/moar.go
@@ -379,7 +379,7 @@ func pagerFromArgs(
 		"Mouse `mode`: auto, select or scroll: https://github.com/walles/moar/blob/master/MOUSE.md",
 		parseMouseMode,
 	)
-	search := flagSet.Bool("search", false, "Start with search mode")
+	search := flagSet.Bool("search", false, "Start in search mode")
 
 	// Combine flags from environment and from command line
 	flags := args[1:]

--- a/moar.go
+++ b/moar.go
@@ -379,6 +379,7 @@ func pagerFromArgs(
 		"Mouse `mode`: auto, select or scroll: https://github.com/walles/moar/blob/master/MOUSE.md",
 		parseMouseMode,
 	)
+	search := flagSet.Bool("search", false, "Start with search mode")
 
 	// Combine flags from environment and from command line
 	flags := args[1:]
@@ -574,6 +575,7 @@ func pagerFromArgs(
 	pager.ScrollLeftHint = *scrollLeftHint
 	pager.ScrollRightHint = *scrollRightHint
 	pager.SideScrollAmount = int(*shift)
+	pager.ShouldStartWithSearch = *search
 
 	pager.TargetLine = targetLine
 	if *follow && pager.TargetLine == nil {

--- a/twin/keys.go
+++ b/twin/keys.go
@@ -23,6 +23,8 @@ const (
 	KeyEnd
 	KeyPgUp
 	KeyPgDown
+
+	KeyCtrlD
 )
 
 // Map incoming escape keystrokes to keycodes, used in consumeEncodedEvent() in
@@ -68,4 +70,6 @@ var escapeSequenceToKeyCode = map[string]KeyCode{
 	"\x1b[4~": KeyEnd,
 	"\x1b[5~": KeyPgUp,
 	"\x1b[6~": KeyPgDown,
+
+	"\x04": KeyCtrlD, // CTRL + D
 }


### PR DESCRIPTION
motivation: I'm using `moar` as the pager for searching the buffer in the kitty terminal. this flag enables dropping into search mode directly so you can start typing right away instead of pressing `/` first