### PR TITLE
Improve performance with wrapped lines

### DIFF
--- a/m/linewrapper.go
+++ b/m/linewrapper.go
@@ -1,7 +1,6 @@
 package m
 
 import (
-	"fmt"
 	"unicode"
 
 	"github.com/walles/moar/twin"
@@ -15,11 +14,6 @@ const NO_BREAK_SPACE = '\xa0'
 // Given some text and a maximum width in screen cells, find the best point at
 // which to wrap the text. Return value is in number of runes.
 func getWrapCount(line []twin.StyledRune, maxScreenCellsCount int) int {
-	if getScreenCellCount(line) <= maxScreenCellsCount {
-		panic(fmt.Errorf("cannot compute wrap width when input isn't wider than max (%d<=%d)",
-			len(line), maxScreenCellsCount))
-	}
-
 	screenCells := 0
 	bestCutPoint := maxScreenCellsCount
 	inLeadingWhitespace := true

--- a/m/linewrapper_test.go
+++ b/m/linewrapper_test.go
@@ -131,3 +131,22 @@ func TestGetWrapCountWideChars(t *testing.T) {
 	assert.Equal(t, getWrapCount(line, 2), 1)
 	assert.Equal(t, getWrapCount(line, 1), 1)
 }
+
+func BenchmarkWrapLine(b *testing.B) {
+	words := "Here are some words of different lengths, some of which are very long, and some of which are short. "
+	lineLen := 60_000
+	line := ""
+	for len(line) < lineLen {
+		line += words
+	}
+	line = line[:lineLen]
+
+	styledRunes := tokenize(line)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = wrapLine(73, styledRunes)
+	}
+
+	b.StopTimer()
+}


### PR DESCRIPTION
Inspired by the work on #290.

According to the newly introduced wrapping benchmark, these changes makes line wrapping 266x faster.

It's still not great, but at least a lot less bad.