### PR TITLE
Let plaining happen lazily

### DIFF
--- a/internal/filteringReader.go
+++ b/internal/filteringReader.go
@@ -53,7 +53,7 @@ func (f *FilteringReader) rebuildCache() {
 	allBaseLines := f.BackingReader.GetLines(linemetadata.Index{}, math.MaxInt)
 	resultIndex := 0
 	for _, line := range allBaseLines.Lines {
-		if filterPattern != nil && len(filterPattern.String()) > 0 && !filterPattern.MatchString(line.Line.Plain()) {
+		if filterPattern != nil && len(filterPattern.String()) > 0 && !filterPattern.MatchString(line.Line.Plain(line.Index)) {
 			// We have a pattern but it doesn't match
 			continue
 		}

--- a/internal/reader/line.go
+++ b/internal/reader/line.go
@@ -8,23 +8,17 @@ import (
 	"github.com/walles/moor/v2/twin"
 )
 
-// A Line represents a line of text that can / will be paged
-type Line struct {
-	raw   string
-	plain string
-}
-
 // Returns a representation of the string split into styled tokens. Any regexp
 // matches are highlighted. A nil regexp means no highlighting.
 func (line *Line) HighlightedTokens(
 	plainTextStyle twin.Style,
 	searchHitStyle twin.Style,
 	search *regexp.Regexp,
-	lineIndex *linemetadata.Index,
+	lineIndex linemetadata.Index,
 ) textstyles.StyledRunesWithTrailer {
-	matchRanges := getMatchRanges(line.Plain(), search)
+	matchRanges := getMatchRanges(line.Plain(lineIndex), search)
 
-	fromString := textstyles.StyledRunesFromString(plainTextStyle, line.raw, lineIndex)
+	fromString := textstyles.StyledRunesFromString(plainTextStyle, line.raw, &lineIndex)
 	returnRunes := make([]textstyles.CellWithMetadata, 0, len(fromString.StyledRunes))
 	lastWasSearchHit := false
 	for _, token := range fromString.StyledRunes {
@@ -49,11 +43,6 @@ func (line *Line) HighlightedTokens(
 		Trailer:           fromString.Trailer,
 		ContainsSearchHit: !matchRanges.Empty(),
 	}
-}
-
-// Plain returns a plain text representation of the initial string
-func (line *Line) Plain() string {
-	return line.plain
 }
 
 func (line *Line) HasManPageFormatting() bool {

--- a/internal/reader/line_test.go
+++ b/internal/reader/line_test.go
@@ -42,7 +42,7 @@ func TestSearchHitSpanningWrapBoundary(t *testing.T) {
 	// Match runs from indices 3..8 inclusive ("345678")
 	pattern := regexp.MustCompile("345678")
 	searchHitStyle := twin.StyleDefault.WithForeground(twin.NewColor16(3))
-	highlighted := line.HighlightedTokens(twin.StyleDefault, searchHitStyle, pattern, nil)
+	highlighted := line.HighlightedTokens(twin.StyleDefault, searchHitStyle, pattern, linemetadata.Index{})
 
 	// Sanity: overall line reports having a search hit
 	assert.Assert(t, highlighted.ContainsSearchHit, "Expected overall line to contain search hit")

--- a/internal/reader/numberedLine.go
+++ b/internal/reader/numberedLine.go
@@ -12,15 +12,15 @@ import (
 type NumberedLine struct {
 	Index  linemetadata.Index
 	Number linemetadata.Number
-	Line   Line
+	Line   *Line
 }
 
 func (nl *NumberedLine) Plain() string {
-	return nl.Line.Plain()
+	return nl.Line.Plain(nl.Index)
 }
 
 func (nl *NumberedLine) HighlightedTokens(plainTextStyle twin.Style, searchHitStyle twin.Style, search *regexp.Regexp) textstyles.StyledRunesWithTrailer {
-	return nl.Line.HighlightedTokens(plainTextStyle, searchHitStyle, search, &nl.Index)
+	return nl.Line.HighlightedTokens(plainTextStyle, searchHitStyle, search, nl.Index)
 }
 
 func (nl *NumberedLine) DisplayWidth() int {

--- a/internal/reader/reader_test.go
+++ b/internal/reader/reader_test.go
@@ -604,28 +604,6 @@ func TestClipRangeToLength(t *testing.T) {
 	assert.Equal(t, i1, 3)
 }
 
-// Fetching lines should fill in the plain text
-func TestCachePlainText(t *testing.T) {
-	reader := NewFromTextForTesting("TestCachePlainText", "Hällo\nWörld")
-	assert.NilError(t, reader.Wait())
-
-	assert.Equal(t, reader.GetLineCount(), 2)
-
-	// Plain should initially be nil
-	assert.Assert(t, reader.lines[0].plainTextCache.Load() == nil)
-	assert.Assert(t, reader.lines[1].plainTextCache.Load() == nil)
-
-	// Getting one line should populate its plain text
-	reader.GetLine(linemetadata.IndexFromOneBased(2))
-	assert.Assert(t, reader.lines[0].plainTextCache.Load() == nil)
-	assert.Assert(t, reader.lines[1].plainTextCache.Load() != nil)
-
-	// Getting multiple lines should populate their plain text
-	reader.GetLines(linemetadata.IndexFromOneBased(1), 2)
-	assert.Assert(t, reader.lines[0].plainTextCache.Load() != nil)
-	assert.Assert(t, reader.lines[1].plainTextCache.Load() != nil)
-}
-
 // How long does it take to read a file?
 //
 // This can be slow due to highlighting.

--- a/internal/scrollPosition.go
+++ b/internal/scrollPosition.go
@@ -323,7 +323,7 @@ func (p *Pager) scrollToEnd() {
 
 	// Scroll down enough. We know for sure the last line won't wrap into more
 	// lines than the number of characters it contains.
-	p.scrollPosition.internalDontTouch.deltaScreenLines = len(lastInputLine.Line.Plain())
+	p.scrollPosition.internalDontTouch.deltaScreenLines = len(lastInputLine.Line.Plain(lastInputIndex))
 
 	if p.TargetLine == nil {
 		// Start following the end of the file

--- a/internal/search-linescanner_test.go
+++ b/internal/search-linescanner_test.go
@@ -105,14 +105,13 @@ func benchmarkSearch(b *testing.B, highlighted bool, warm bool) {
 	// we're searching through this very file.
 	pattern := regexp.MustCompile("This won'[t] match anything")
 
+	reader.DisablePlainCachingForBenchmarking = !warm
 	if warm {
 		// Warm up any caches etc by doing one search before we start measuring
 		hit := FindFirstHit(benchMe, *pattern, linemetadata.Index{}, nil, SearchDirectionForward)
 		if hit != nil {
 			panic(fmt.Errorf("This test is meant to scan the whole file without finding anything"))
 		}
-	} else {
-		benchMe.DisableCacheForBenchmarking()
 	}
 
 	// I hope forcing a GC here will make numbers more predictable


### PR DESCRIPTION
This improves cold search performance by 10-20% in benchmarks.
