### PR TITLE
Reset terminal attributes on exit

### DIFF
--- a/twin/screen.go
+++ b/twin/screen.go
@@ -229,6 +229,7 @@ func (screen *UnixScreen) Close() {
 	// Tell our main loop to exit
 	screen.ttyInReader.Interrupt()
 
+	screen.write("\x1b[m")
 	screen.hideCursor(false)
 	screen.enableMouseTracking(false)
 	screen.setAlternateScreenMode(false)


### PR DESCRIPTION
This PR fixes an issue where `moor` would leave terminal attributes set upon exit, affecting the background color of the alternate screen buffer for subsequent commands.

**Reproduction Steps:**
1. Open a terminal in [**Ghostty**](https://github.com/ghostty-org/ghostty).
2. Run the following command to check the alternate screen's state:
   ```bash
   printf '\e[?1049h'; sleep 1; printf '\e[?1049l'
   ```
   *Observation:* The alternate screen flashes briefly, and its background color should match the terminal's default background.
3. Run `moor` (e.g., `moor some_file.txt`) and then exit it.
4. Run the command from step 2 again:
   ```bash
   printf '\e[?1049h'; sleep 1; printf '\e[?1049l'
   ```
   *Observation:* The alternate screen now incorrectly flashes with a white background (or another non-default color), indicating that the background color attributes were not cleared by `moor`.

**The Fix:**
Added a write of the reset escape sequence (`\x1b[m`) in `UnixScreen.Close()` before disabling the alternate screen. This ensures the terminal attributes are reset to defaults when `moor` exits.