### PR TITLE
Avoid discrimination based on etnicity or place of birth

### DIFF
--- a/cmd/moor/moor.go
+++ b/cmd/moor/moor.go
@@ -308,26 +308,6 @@ func getTargetLine(args []string) (*linemetadata.Index, []string) {
 	return nil, args
 }
 
-func russiaNotSupported() {
-	if !strings.HasPrefix(strings.ToLower(os.Getenv("LANG")), "ru_ru") {
-		// Not russia
-		return
-	}
-
-	if os.Getenv("CRIMEA") == "Ukraine" {
-		// It is!
-		return
-	}
-
-	fmt.Fprintln(os.Stderr, "ERROR: russia not supported (but Russian is!)")
-	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, "Options for using moor in Russian:")
-	fmt.Fprintln(os.Stderr, "* Change your language setting to ru_UA.UTF-8")
-	fmt.Fprintln(os.Stderr, "* Set CRIMEA=Ukraine in your environment")
-	fmt.Fprintln(os.Stderr, "* russia leaves Ukraine")
-	os.Exit(1)
-}
-
 // For git output and man pages, disable line numbers by default.
 //
 // Before paging, "man" first checks the terminal width and formats the man page
@@ -651,7 +631,6 @@ func main() {
 	logsRequested := false
 	log.SetOutput(&loglines)
 	twin.SetLogger(&util.TwinLogger{})
-	russiaNotSupported()
 
 	defer func() {
 		err := recover()


### PR DESCRIPTION
The act of violence against other countries, cultures or populations is unacceptable. No matter if the aggressor is the Russia government, the Israeli one, China or USA. To oppose to the tendencies of certain governments and political leaders it's critical that the civil population can collaborate independently of the ruling government. To that regard, the development of the internet helped in big deal. In the past as in the present, different activist could collaborate between them even while living in oppressive regimes thanks to the culture of collaborating with each other. This in turn helped to fight against their own oppressive regime. For this, it was essential that technology was open and transparent.

Discriminating against people who happen to live in Russia is a bad precedent that damages this shared culture that created most of what we can enjoy today. The ones who oppose to the current Russian government are already facing consequences for their political views and if this kind of chances become a tendency it could make the life of the same activist that oppose to the war more difficult, causing the opposite effect that is desired

Moreover, due to the war of Russia in Ukraine, more Russian-speaking population in Ukraine seems to be worried about the language and try to promote and change to use Ukrainian. Given the LANG and other locales are sometimes used for statistics, forcing population not in Ukraine to use ru_UA is promoting a policy that hurts the interests of the Ukrainian population as it could appear there are more Russian speakers in Ukraine that the ones there really are.

For all this reasons, I think It would be better to revert commit https://github.com/walles/moor/commit/1a29aa8c0cfba919e7e58c2bba72c578d4e3be5e
Thank you for your time and consideration.