### PR TITLE
Support CTRL-f and CTRL-b for paging

### DIFF
--- a/internal/pagermode-viewing.go
+++ b/internal/pagermode-viewing.go
@@ -141,11 +141,15 @@ func (m PagerModeViewing) onRune(char rune) {
 	case '>', 'G':
 		p.scrollToEnd()
 
-	case 'f', ' ':
+	// '\x06' = CTRL-f, should work like just 'f'.
+	// Ref: https://github.com/walles/moor/issues/107
+	case 'f', ' ', '\x06':
 		p.scrollPosition = p.scrollPosition.NextLine(p.visibleHeight())
 		p.handleScrolledDown()
 
-	case 'b':
+	// '\x02' = CTRL-b, should work like just 'b'.
+	// Ref: https://github.com/walles/moor/issues/107
+	case 'b', '\x02':
 		p.scrollPosition = p.scrollPosition.PreviousLine(p.visibleHeight())
 		p.handleScrolledUp()
 


### PR DESCRIPTION
## Summary
- Add CTRL-f (page down) and CTRL-b (page up) keybindings, matching vim/less muscle memory
- These complement the existing CTRL-d/u (half-page) and CTRL-n/p (single line) bindings

Related to #107.

## Test plan
- Built and verified manually: CTRL-f pages down, CTRL-b pages up
- Existing `f`/`b`/space behavior unchanged