### PR TITLE
Fix file descriptor leak by closing input stream when reading completes

### DIFF
--- a/internal/pager_test.go
+++ b/internal/pager_test.go
@@ -522,11 +522,6 @@ func TestPageSamples(t *testing.T) {
 				t.Errorf("Error opening file <%s>: %s", fileName, err.Error())
 				return
 			}
-			defer func() {
-				if err := file.Close(); err != nil {
-					panic(err)
-				}
-			}()
 
 			myReader, err := reader.NewFromStream(fileName, file, nil, reader.ReaderOptions{Style: &chroma.Style{}})
 			assert.NilError(t, err)

--- a/internal/reader/reader.go
+++ b/internal/reader/reader.go
@@ -167,6 +167,14 @@ type InputLines struct {
 func (reader *ReaderImpl) readStream(stream io.Reader, formatter chroma.Formatter, options ReaderOptions) {
 	reader.consumeLinesFromStream(stream)
 
+	if closer, ok := stream.(io.Closer); ok {
+		// Close the initial stream as soon as we're done reading it,
+		// well before we start tailing or doing expensive highlighting.
+		if err := closer.Close(); err != nil {
+			log.Debug("Failed to close stream after reading initial contents: ", err)
+		}
+	}
+
 	reader.ReadingDone.Store(true)
 	select {
 	case reader.MaybeDone <- true:
@@ -596,6 +604,10 @@ func isSeekableFile(fileName *string) bool {
 
 // NewFromStream creates a new stream reader
 //
+// Note that if the provided io.Reader also implements io.Closer, it will be
+// automatically closed once the reader has finished consuming its initial
+// content.
+//
 // The display name can be an empty string ("").
 //
 // If non-empty, the name will be displayed by the pager in the bottom left
@@ -624,6 +636,9 @@ func NewFromStream(displayName string, reader io.Reader, formatter chroma.Format
 }
 
 // newReaderFromStream creates a new stream reader
+//
+// If the provided io.Reader also implements io.Closer, it will be automatically
+// closed once the reader has finished consuming its initial content.
 //
 // originalFileName is used for counting the lines in the file. nil for
 // don't-know (streams) or not countable (compressed files). The line count is

--- a/internal/reader/reader_test.go
+++ b/internal/reader/reader_test.go
@@ -818,6 +818,7 @@ func TestTailCompressedFileNoReloadLoop(t *testing.T) {
 	options := ReaderOptions{}
 	reader, err := NewFromFilename(tempFile, nil, options)
 	assert.NilError(t, err)
+	defer reader.Close()
 
 	// Wait for it to read the file
 	err = reader.Wait()

--- a/pkg/moor/embed-api.go
+++ b/pkg/moor/embed-api.go
@@ -46,6 +46,11 @@ type Options struct {
 	QuitIfOneScreen bool
 }
 
+// PageFromStream reads the contents of the given reader and presents it in a pager.
+//
+// Note that if the provided reader implements io.Closer, it will be closed
+// automatically once the pager has finished reading from it or when the pager exits.
+//
 // If stdout is not a terminal, the stream contents will just be printed to
 // stdout.
 func PageFromStream(reader io.Reader, options Options) error {


### PR DESCRIPTION
The Windows CI failure in \`TestTailCompressedFileNoReloadLoop\` exposed a real file descriptor leak: the background reader left the input stream open indefinitely.
        
This PR fixes the leak by ensuring that any \`io.Closer\` provided to the reader is explicitly closed as soon as the initial read completes, well before tailing or highlighting. It also:
* Fixes the tests that were failing due to locked files or double-closings.
* Documents this stream-closing behavior in the \`PageFromStream\` embed API so callers know they don't have to close the stream twice.