### PR TITLE
Remove duplicate `.TP` in manpage

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -24,6 +24,10 @@ jobs:
       - name: Install golangci-lint
         run: curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.11.3
 
+        # Required by test.sh
+      - name: Install mandoc
+        run: sudo apt-get update && sudo apt-get install -y mandoc
+
       - run: go build ./...
       - run: ./test.sh
       - run: GOARCH=386 ./test.sh

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -26,7 +26,7 @@ jobs:
 
         # Required by test.sh
       - name: Install mandoc
-        run: sudo apt-get update && sudo apt-get install -y mandoc
+        run: sudo apt-get install -y mandoc
 
       - run: go build ./...
       - run: ./test.sh

--- a/moor.1
+++ b/moor.1
@@ -73,7 +73,6 @@ Hide line numbers on startup, press left arrow key to show
 \fB\-\-no\-reformat\fR
 No effect, exists for backwards compatibility. See --reformat.
 .TP
-.TP
 \fB\-\-no\-search\-line\-highlight\fR
 Do not highlight the background of lines with search hits. The search hits themselves are still highlighted though, even with this option.
 .TP

--- a/moor.1
+++ b/moor.1
@@ -136,7 +136,7 @@ Print trace logs after exiting, more verbose than
 Wrap long lines, toggle with
 .B w
 .TP
-\fB\+\1234\fR
+\fB+1234\fR
 Immediately scroll to line
 .B 1234
 .SH FILES

--- a/test.sh
+++ b/test.sh
@@ -103,6 +103,11 @@ echo Test --version...
 ./moor --version >/dev/null # Should exit with code 0
 diff -u <(./moor --version) <(git describe --tags --dirty --always)
 
+echo "Linting man page..."
+# -T lint enables the linter
+# -W warning ignores "STYLE" hints (like line length) but catches structural issues
+mandoc -T lint -W warning moor.1
+
 echo Test that the man page and --help document the same set of options...
 MAN_OPTIONS="$(grep -A1 '^\.TP$' moor.1 | grep -E '^\\fB\\-' | cut -d\\ -f4- | sed 's/fR.*//' | sed 's/\\//g')"
 MOOR_OPTIONS="$(./moor --help | grep -E '^  -' | cut -d' ' -f3 | grep -v -- -version)"


### PR DESCRIPTION
This produces a warning from groff and doesn't appear to do anything.
