### PR TITLE
Added LRU for the line renderer.

### DIFF
--- a/cmd/moor/moor.go
+++ b/cmd/moor/moor.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime"
 	"runtime/debug"
+	"runtime/pprof"
 	"strconv"
 	"strings"
 	"time"
@@ -396,6 +397,9 @@ func pagerFromArgs(
 	debug := flagSet.Bool("debug", false, "Print debug logs after exiting")
 	trace := flagSet.Bool("trace", false, "Print trace logs after exiting")
 
+	profile_file := flagSet.String("profile", "", "Path to write profile information")
+	lru_size := flagSet.Int("lru_size", 100, "Size of the LRU for the page cache")
+
 	wrap := flagSet.Bool("wrap", false, "Wrap long lines")
 	follow := flagSet.Bool("follow", false, "Follow piped input just like \"tail -f\"")
 	styleOption := flagSetFunc(flagSet,
@@ -639,6 +643,8 @@ func pagerFromArgs(
 	pager.SideScrollAmount = int(*shift)
 	pager.TabSize = int(*tabSize)
 	pager.WithSearchHitLineBackground = !*noSearchLineHighlight
+	pager.ProfileFile = *profile_file
+	pager.LRUSize = *lru_size
 
 	pager.TargetLine = targetLine
 	if *follow && pager.TargetLine == nil {
@@ -701,6 +707,19 @@ func main() {
 	if pager == nil {
 		// No pager, we're done
 		return
+	}
+
+	if pager.ProfileFile != "" {
+		fd, err := os.Create(pager.ProfileFile)
+		if err != nil {
+			log.Debug("Unable to create profile file", pager.ProfileFile, err)
+
+		} else {
+			err = pprof.StartCPUProfile(fd)
+			if err == nil {
+				defer pprof.StopCPUProfile()
+			}
+		}
 	}
 
 	startPaging(pager, screen, &style, formatter)

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,8 @@ require (
 	gotest.tools/v3 v3.3.0
 )
 
+require github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+
 require (
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	golang.org/x/sync v0.20.0

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cn
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/klauspost/compress v1.17.4 h1:Ej5ixsIri7BrIjBkRZLTo6ghwrEtHFk7ijlczPW4fZ4=

--- a/internal/filteringReader.go
+++ b/internal/filteringReader.go
@@ -39,6 +39,13 @@ type FilteringReader struct {
 	filterWhenCaching search.Search
 }
 
+func (f *FilteringReader) Fingerprint() string {
+	return fmt.Sprintf("%v:%v",
+		f.BackingReader.Fingerprint(),
+		f.Filter.Fingerprint(),
+	)
+}
+
 // Please hold the lock when calling this method.
 //
 // This method requires f.Filter.Active() to be true on entry.

--- a/internal/pager.go
+++ b/internal/pager.go
@@ -151,7 +151,7 @@ func (p *Pager) Fingerprint() string {
 		p.filter.Fingerprint(),
 		p.WrapLongLines,
 		p.showLineNumbers,
-		p.SideScrollAmount,
+		p.leftColumnZeroBased,
 		p.TabSize,
 		w,
 		h,

--- a/internal/pager.go
+++ b/internal/pager.go
@@ -146,11 +146,12 @@ type Pager struct {
 func (p *Pager) Fingerprint() string {
 	w, h := p.screen.Size()
 
-	return fmt.Sprintf("%v:%v:%v:%v:%v:%v:%v:%v",
+	return fmt.Sprintf("%v:%v:%v:%v:%v:%v:%v:%v:%v",
 		p.search.Fingerprint(),
 		p.filter.Fingerprint(),
 		p.WrapLongLines,
 		p.showLineNumbers,
+		p.isShowingHelp,
 		p.leftColumnZeroBased,
 		p.TabSize,
 		w,

--- a/internal/pager.go
+++ b/internal/pager.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/alecthomas/chroma/v2"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 	log "github.com/sirupsen/logrus"
 	"github.com/walles/moor/v2/internal/linemetadata"
 	"github.com/walles/moor/v2/internal/reader"
@@ -124,6 +125,10 @@ type Pager struct {
 	// actual hits)
 	WithSearchHitLineBackground bool
 
+	LRUSize int
+
+	ProfileFile string
+
 	// Length of the longest line displayed. This is used for limiting scrolling
 	// to the right.
 	longestLineLength int
@@ -132,6 +137,25 @@ type Pager struct {
 	//
 	// Ref: https://github.com/walles/moor/issues/175
 	bookmarks map[rune]scrollPosition
+
+	cache *simplelru.LRU[string, []renderedLine]
+}
+
+// Get a unique fingerprint representing the current immutable state
+// of the pager. This is used to cache the state.
+func (p *Pager) Fingerprint() string {
+	w, h := p.screen.Size()
+
+	return fmt.Sprintf("%v:%v:%v:%v:%v:%v:%v:%v",
+		p.search.Fingerprint(),
+		p.filter.Fingerprint(),
+		p.WrapLongLines,
+		p.showLineNumbers,
+		p.SideScrollAmount,
+		p.TabSize,
+		w,
+		h,
+	)
 }
 
 type _PreHelpState struct {

--- a/internal/pager.go
+++ b/internal/pager.go
@@ -145,8 +145,7 @@ type Pager struct {
 // of the pager. This is used to cache the state.
 func (p *Pager) Fingerprint() string {
 	w, h := p.screen.Size()
-
-	return fmt.Sprintf("%v:%v:%v:%v:%v:%v:%v:%v:%v",
+	return fmt.Sprintf("%v:%v:%v:%v:%v:%v:%v:%v:%v:%v",
 		p.search.Fingerprint(),
 		p.filter.Fingerprint(),
 		p.WrapLongLines,
@@ -154,6 +153,7 @@ func (p *Pager) Fingerprint() string {
 		p.isShowingHelp,
 		p.leftColumnZeroBased,
 		p.TabSize,
+		p.Reader().Fingerprint(),
 		w,
 		h,
 	)

--- a/internal/reader/reader.go
+++ b/internal/reader/reader.go
@@ -73,6 +73,8 @@ type Reader interface {
 	// When we're not paused, the number will be constantly changing, indicating
 	// that the counting is not done yet.
 	ShouldShowLineCount() bool
+
+	Fingerprint() string
 }
 
 // ReaderImpl reads a file into an array of strings.
@@ -119,6 +121,8 @@ type ReaderImpl struct {
 
 	highlightingStyle chan chroma.Style
 
+	version int
+
 	// This channel expects to be read exactly once. All other uses will lead to
 	// undefined behavior.
 	doneWaitingForFirstByte chan bool
@@ -147,6 +151,18 @@ type ReaderImpl struct {
 
 	// Set to true when this reader is discarded.
 	closed atomic.Bool
+}
+
+func (reader *ReaderImpl) Fingerprint() string {
+	return fmt.Sprintf("%v:%v:%v:%v:%v",
+		// These are pointers to strings so their address is
+		// immutable.
+		reader.FileName,
+		reader.DisplayName,
+
+		reader.HighlightingDone.Load(),
+		reader.ReadingDone.Load(),
+		reader.version)
 }
 
 // InputLines contains a number of lines from the reader, plus metadata
@@ -552,6 +568,7 @@ func (reader *ReaderImpl) setText(text string) {
 
 	reader.Lock()
 	reader.lines = lines
+	reader.version++
 	reader.Unlock()
 
 	log.Trace("Reader done, contents explicitly set")

--- a/internal/screenLines.go
+++ b/internal/screenLines.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/hashicorp/golang-lru/v2/simplelru"
 	log "github.com/sirupsen/logrus"
 	"github.com/walles/moor/v2/internal/linemetadata"
 	"github.com/walles/moor/v2/internal/reader"
@@ -214,6 +215,35 @@ func (p *Pager) internalRenderLines(highlightSearchHitLines bool) renderedScreen
 // lineNumber and numberPrefixLength are required for knowing how much to
 // indent, and to (optionally) render the line number.
 func (p *Pager) renderLine(line reader.NumberedLine, numberPrefixLength int, highlightSearchHitLines bool) []renderedLine {
+	key := fmt.Sprintf("%v:%v:%v:%v",
+		line.Index,
+		numberPrefixLength,
+		highlightSearchHitLines,
+		p.Fingerprint(),
+	)
+	if p.cache == nil {
+		p.clearCache()
+	}
+
+	res, ok := p.cache.Get(key)
+	if ok {
+		return res
+	}
+
+	res = p._renderLine(line, numberPrefixLength, highlightSearchHitLines)
+	p.cache.Add(key, res)
+	return res
+}
+
+func (p *Pager) clearCache() {
+	lru_size := p.LRUSize
+	if lru_size == 0 {
+		lru_size = 100
+	}
+	p.cache, _ = simplelru.NewLRU[string, []renderedLine](lru_size, nil)
+}
+
+func (p *Pager) _renderLine(line reader.NumberedLine, numberPrefixLength int, highlightSearchHitLines bool) []renderedLine {
 	width, _ := p.screen.Size()
 	var wrapped []textstyles.StyledRunesWithTrailer
 	var highlighted textstyles.StyledRunesWithTrailer

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -19,6 +19,10 @@ type Search struct {
 	pattern *regexp.Regexp
 }
 
+func (search Search) Fingerprint() string {
+	return search.findMe
+}
+
 func (search Search) Equals(other Search) bool {
 	return search.findMe == other.findMe
 }
@@ -124,9 +128,10 @@ func (search Search) GetMatchRanges(String string) *MatchRanges {
 		String = strings.ToLower(String)
 	}
 
-	return &MatchRanges{
+	res := &MatchRanges{
 		Matches: toRunePositions(search.pattern.FindAllStringIndex(String, -1), String),
 	}
+	return res
 }
 
 // Convert byte indices to rune indices


### PR DESCRIPTION
Rendering very long lines is quite expensive, especially when they need to be searched for highlighting. The code previously issued a call to Pager.renderLine for each line each time the screen was redrawn (for example when the user pressed up or down to move by one line, each other line was recalculated).

Profiling shows the renderLine function was very hot.

This PR adds an LRU to that function where the result of calculating the line is cached. This speeds up performance by a lot.

To test, create a large text file with multiple very long lines at the end (I used about 100kb per line). When not in wrapping mode, the line will be truncated. However, before this PR pressing up/down when the start of the long line is visible takes multiple seconds to redraw.

After this PR redrawing is much smoother, as the lines are cached once they are displayed, so when the user pressed up/down only the newly visible line might be recalculated.

To make sure the cache is invalidated properly, a fingerprint function is added to various objects to capture their state relative to the cached lines.