### PR TITLE
Cache search results per line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+all:
+	go build ./cmd/moor
+
+windows:
+	GOOS=windows go build ./cmd/moor

--- a/internal/file-switching.go
+++ b/internal/file-switching.go
@@ -13,6 +13,7 @@ func (p *Pager) previousFile() {
 		newIndex = 0
 	}
 	p.currentReader = newIndex
+	p.searchCache.SetReaderIdx(newIndex)
 	log.Tracef("Switched to previous file, index %d", p.currentReader)
 
 	select {
@@ -30,6 +31,7 @@ func (p *Pager) nextFile() {
 		newIndex = len(p.readers) - 1
 	}
 	p.currentReader = newIndex
+	p.searchCache.SetReaderIdx(newIndex)
 	log.Tracef("Switched to next file, index %d", p.currentReader)
 
 	select {
@@ -43,6 +45,7 @@ func (p *Pager) firstFile() {
 	defer p.readerLock.Unlock()
 
 	p.currentReader = 0
+	p.searchCache.SetReaderIdx(0)
 	log.Tracef("Switched to first file, index %d", p.currentReader)
 
 	select {

--- a/internal/filteringReader.go
+++ b/internal/filteringReader.go
@@ -275,5 +275,5 @@ func (f *FilteringReader) SetBackingReader(r reader.Reader) {
 	// Invalidate caches so they will be rebuilt lazily on next access.
 	f.filteredLinesCache = nil
 	f.unfilteredLineCountWhenCaching = -1
-	f.filterWhenCaching = search.Search{}
+	f.filterWhenCaching = search.Search{Cache: search.NewSearchCache()}
 }

--- a/internal/pager-search.go
+++ b/internal/pager-search.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"slices"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/walles/moor/v2/internal/linemetadata"
@@ -238,11 +239,8 @@ func (p *Pager) scrollToPreviousSearchHit() {
 // manually to see the rest of the hit.
 func (p *Pager) searchHitIsVisible() bool {
 	for _, row := range p.renderLines().lines {
-		for _, cell := range row.cells {
-			if cell.StartsSearchHit {
-				// Found a search hit on screen!
-				return true
-			}
+		if row.containsSearchHit {
+			return true
 		}
 	}
 
@@ -349,95 +347,27 @@ func (p *Pager) scrollRightToSearchHits() bool {
 		return false
 	}
 
-	restoreShowLineNumbers := p.showLineNumbers
-	restoreLeftColumn := p.leftColumnZeroBased
-
-	// Check how far right we can scroll at most. Factors involved:
-	// - Screen width
-	// - Length of longest visible line
-	screenWidth, _ := p.screen.Size()
-
-	widestLineWidth := 0 // In screen cells, some runes are double-width
 	rendered := p.renderLines()
-	for _, inputLine := range rendered.inputLines {
-		lineLength := inputLine.DisplayWidth()
-		if lineLength > widestLineWidth {
-			widestLineWidth = lineLength
-		}
-	}
-
-	// With a 10 wide screen and a 15 wide line (max index 14), the leftmost
-	// screen column can at most be 5:
-	//
-	// Screen column: 0123456789
-	// Line column:   5678901234
-	maxLeftmostColumn := widestLineWidth - screenWidth
-
-	// If we have line numbers and disable them, do any new hits appear?
-	if rendered.numberPrefixWidth > 0 {
-		// If the number prefix width is 4, and the screen width is 10, then 6 should be
-		// the first newly revealed column index (10-4):
-		//
-		// Screen column: 0123456789
-		// New cells:     ______1234
-		//
-		// But since the rightmost column can be covered by scroll-right we need to subtract
-		// one more and get to 5.
-		firstJustRevealedColumn := screenWidth - rendered.numberPrefixWidth - 1
-		if firstJustRevealedColumn <= 0 {
-			log.Info("Screen too narrow ({}) to disable line numbers for search hits, skipping", screenWidth)
-			return false
-		}
-
-		p.showLineNumbers = false
-		for _, row := range p.renderLines().lines {
-			for column := firstJustRevealedColumn; column < len(row.cells); column++ {
-				if row.cells[column].StartsSearchHit {
-					// Found a search hit on screen!
-					return true
-				}
+	width, _ := p.screen.Size()
+	offscreenColumn := p.leftColumnZeroBased + width + 1
+	var nextHitOffset []int
+	for _, line := range rendered.lines {
+		for _, hit := range line.searchHits.Matches {
+			if hit[0] > offscreenColumn {
+				nextHitOffset = append(nextHitOffset, hit[0])
 			}
 		}
-		p.showLineNumbers = restoreShowLineNumbers
 	}
 
-	for p.leftColumnZeroBased < maxLeftmostColumn {
-		// FIXME: Rather than scrolling right one screen at a time, we should
-		// consider scanning all lines for search hits and scrolling directly to the
-		// first one that is off-screen to the right.
-
-		// If the screen width is 1, and we have no line numbers, the answer
-		// could be 1. But since the last column could be covered by scroll-right
-		// markers, we'll say 0.
-		firstNotVisibleColumn := p.leftColumnZeroBased + screenWidth - rendered.numberPrefixWidth - 1
-		if firstNotVisibleColumn < 1 {
-			log.Info("Screen is narrower than number prefix length, not scrolling right for search hits")
-			p.showLineNumbers = restoreShowLineNumbers
-			p.leftColumnZeroBased = restoreLeftColumn
-			return false
-		}
-
-		// Minus one to account for the scroll-left marker that will cover the
-		// first column after scrolling.
-		scrollToColumn := firstNotVisibleColumn - 1
-
-		p.showLineNumbers = false
-		p.leftColumnZeroBased = scrollToColumn
-
-		if p.searchHitIsVisible() {
-			// A new hit showed up!
-			if p.leftColumnZeroBased > maxLeftmostColumn {
-				// Scrolled beyond max, adjust
-				p.leftColumnZeroBased = maxLeftmostColumn
-			}
-			return true
-		}
+	// No hits at all in these lines.
+	if len(nextHitOffset) == 0 {
+		return false
 	}
 
-	// Can't scroll right, pretend nothing happened
-	p.showLineNumbers = restoreShowLineNumbers
-	p.leftColumnZeroBased = restoreLeftColumn
-	return false
+	// Move the left size to the next most hit.
+	p.leftColumnZeroBased = slices.Min(nextHitOffset)
+
+	return true
 }
 
 // Scroll left looking for search hits. Return true if we found any.
@@ -447,79 +377,26 @@ func (p *Pager) scrollLeftToSearchHits() bool {
 		return false
 	}
 
-	restoreLeftColumn := p.leftColumnZeroBased
-	restoreShowLineNumbers := p.showLineNumbers
-
-	screenWidth, _ := p.screen.Size()
-
-	// If we go max left, which column will be the rightmost visible one?
-	var fullLeftRightmostVisibleColumn int
-	{
-		p.showLineNumbers = p.ShowLineNumbers
-		p.leftColumnZeroBased = 0
-		rendered := p.renderLines()
-		// If the screen width is 2, we have columns 0 and 1. The rightmost column can be covered by
-		// scroll-right markers, so the first not-visible column when fully scrolled left is 0, or
-		// "2 - 2".
-		fullLeftRightmostVisibleColumn = screenWidth - 2 - rendered.numberPrefixWidth
-
-		p.leftColumnZeroBased = restoreLeftColumn
-		p.showLineNumbers = restoreShowLineNumbers
+	rendered := p.renderLines()
+	offscreenColumn := p.leftColumnZeroBased
+	var nextHitOffset []int
+	for _, line := range rendered.lines {
+		for _, hit := range line.searchHits.Matches {
+			if hit[0] < offscreenColumn {
+				nextHitOffset = append(nextHitOffset, hit[0])
+			}
+		}
 	}
 
-	if fullLeftRightmostVisibleColumn < 0 {
-		log.Info("Screen too narrow ({}) to scroll left for search hits, skipping", screenWidth)
+	// No hits at all in these lines.
+	if len(nextHitOffset) == 0 {
 		return false
 	}
 
-	// Keep scrolling left until we either find a search hit, or reach the
-	// leftmost column with line numbers shown or not based on the user's
-	// preference.
-	for p.leftColumnZeroBased > 0 || (p.showLineNumbers != p.ShowLineNumbers) {
-		// FIXME: Rather than scrolling left one screen at a time, we should
-		// consider scanning all lines for search hits and scrolling directly to the
-		// first one that is off-screen to the left.
+	// Move the left size to the next most hit.
+	p.leftColumnZeroBased = slices.Max(nextHitOffset)
 
-		// Pretend the current leftmost column is not visible, since it could be
-		// covered by scroll-left markers.
-		lastNotVisibleColumn := p.leftColumnZeroBased
-
-		// Go left
-		if lastNotVisibleColumn <= fullLeftRightmostVisibleColumn {
-			// Going max left will show the column we want
-			p.showLineNumbers = p.ShowLineNumbers
-			p.leftColumnZeroBased = 0
-		} else {
-			// Scroll left one screen.
-			//
-			// If the screen width is 3, and we want column 5 to be visible, and
-			// there can be both scroll-left and scroll-right markers, we should
-			// start at colum 4 (covered by a scroll-left marker), so that
-			// column 5 is visible next to it.
-			//
-			// Set the leftmost column to 4, which is "5 - 3 + 2".
-			scrollToColumn := lastNotVisibleColumn - screenWidth + 2
-			if scrollToColumn < 0 {
-				scrollToColumn = 0
-			}
-
-			p.leftColumnZeroBased = scrollToColumn
-
-			// If showing line numbers was possible we should have ended up in
-			// the other if branch ^
-			p.showLineNumbers = false
-		}
-
-		if p.searchHitIsVisible() {
-			// Found it!
-			return true
-		}
-	}
-
-	// Scrolling left didn't find anything, pretend nothing happened
-	p.showLineNumbers = restoreShowLineNumbers
-	p.leftColumnZeroBased = restoreLeftColumn
-	return false
+	return true
 }
 
 func (p *Pager) isViewing() bool {

--- a/internal/pager.go
+++ b/internal/pager.go
@@ -66,7 +66,8 @@ type Pager struct {
 	// mode is better?
 	mode PagerMode
 
-	search search.Search
+	search      search.Search
+	searchCache *search.SearchCache
 
 	// This should never be null while paging. Configured in NewPager().
 	searchHistory *SearchHistory
@@ -237,6 +238,7 @@ func NewPager(readers ...*reader.ReaderImpl) *Pager {
 		ScrollRightHint:             textstyles.CellWithMetadata{Rune: '>', Style: twin.StyleDefault.WithAttr(twin.AttrReverse)},
 		scrollPosition:              newScrollPosition(name),
 		WithSearchHitLineBackground: true,
+		searchCache:                 search.NewSearchCache(),
 	}
 
 	pager.mode = PagerModeViewing{pager: &pager}
@@ -247,6 +249,7 @@ func NewPager(readers ...*reader.ReaderImpl) *Pager {
 
 	searchHistory := BootSearchHistory("")
 	pager.searchHistory = &searchHistory
+	pager.search.Cache = pager.searchCache
 
 	return &pager
 }
@@ -569,7 +572,9 @@ func (p *Pager) StartPaging(screen twin.Screen, chromaStyle *chroma.Style, chrom
 			select {
 			case <-p.readerSwitched:
 				// A different reader is now active
-				p.filter = search.Search{}
+				p.filter = search.Search{
+					Cache: p.searchCache,
+				}
 
 				p.readerLock.Lock()
 				r = p.readers[p.currentReader]
@@ -795,8 +800,11 @@ func (p *Pager) fitsOnOneScreen() bool {
 
 	lines := reader.GetLines(linemetadata.Index{}, reader.GetLineCount())
 	for _, line := range lines.Lines {
-		rendered := line.HighlightedTokens(twin.StyleDefault, twin.StyleDefault, search.Search{}, width+1).StyledRunes
-		if len(rendered) > width {
+		rendered, _ := line.HighlightedTokens(
+			twin.StyleDefault, twin.StyleDefault, search.Search{
+				Cache: p.searchCache,
+			}, width+1)
+		if len(rendered.StyledRunes) > width {
 			// This line is too long to fit on one screen line, no fit
 			return false
 		}

--- a/internal/pagermode-filter.go
+++ b/internal/pagermode-filter.go
@@ -44,7 +44,9 @@ func (m *PagerModeFilter) onKey(key twin.KeyCode) {
 
 	case twin.KeyEscape:
 		m.pager.mode = PagerModeViewing{pager: m.pager}
-		m.pager.filter = search.Search{}
+		m.pager.filter = search.Search{
+			Cache: m.pager.searchCache,
+		}
 		m.pager.search.Clear()
 
 	case twin.KeyUp, twin.KeyDown, twin.KeyPgUp, twin.KeyPgDown:

--- a/internal/reader/line.go
+++ b/internal/reader/line.go
@@ -22,11 +22,11 @@ type Line struct {
 func (line *Line) HighlightedTokens(
 	plainTextStyle twin.Style,
 	searchHitStyle twin.Style,
-	search search.Search,
+	search_term search.Search,
 	lineIndex linemetadata.Index,
 	maxTokensCount int,
-) textstyles.StyledRunesWithTrailer {
-	matchRanges := search.GetMatchRanges(line.Plain(lineIndex))
+) (textstyles.StyledRunesWithTrailer, search.MatchRanges) {
+	matchRanges := search_term.GetMatchRanges(line.Plain(lineIndex), lineIndex)
 
 	fromString := textstyles.StyledRunesFromString(plainTextStyle, string(line.raw), &lineIndex, maxTokensCount)
 	returnRunes := make([]textstyles.CellWithMetadata, 0, len(fromString.StyledRunes))
@@ -52,7 +52,7 @@ func (line *Line) HighlightedTokens(
 		StyledRunes:       returnRunes,
 		Trailer:           fromString.Trailer,
 		ContainsSearchHit: !matchRanges.Empty(),
-	}
+	}, matchRanges
 }
 
 func (line *Line) HasManPageFormatting() bool {

--- a/internal/reader/numberedLine.go
+++ b/internal/reader/numberedLine.go
@@ -20,7 +20,9 @@ func (nl *NumberedLine) Plain() string {
 
 // maxTokensCount: at most this many tokens will be included in the result. If
 // 0, do all runes. For BenchmarkRenderHugeLine() performance.
-func (nl *NumberedLine) HighlightedTokens(plainTextStyle twin.Style, searchHitStyle twin.Style, search search.Search, maxTokensCount int) textstyles.StyledRunesWithTrailer {
+func (nl *NumberedLine) HighlightedTokens(plainTextStyle twin.Style,
+	searchHitStyle twin.Style, search search.Search,
+	maxTokensCount int) (textstyles.StyledRunesWithTrailer, search.MatchRanges) {
 	return nl.Line.HighlightedTokens(plainTextStyle, searchHitStyle, search, nl.Index, maxTokensCount)
 }
 

--- a/internal/screenLines.go
+++ b/internal/screenLines.go
@@ -7,7 +7,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/walles/moor/v2/internal/linemetadata"
 	"github.com/walles/moor/v2/internal/reader"
+	"github.com/walles/moor/v2/internal/search"
 	"github.com/walles/moor/v2/internal/textstyles"
+	"github.com/walles/moor/v2/internal/util"
 	"github.com/walles/moor/v2/twin"
 )
 
@@ -29,6 +31,8 @@ type renderedLine struct {
 	//
 	// Ref: https://github.com/walles/moor/issues/106
 	trailer twin.Style
+
+	searchHits search.MatchRanges
 }
 
 type renderedScreen struct {
@@ -85,6 +89,9 @@ func (p *Pager) redraw(spinner string) {
 // height. If the status line is visible, you'll get at most one less than the
 // screen height from this method.
 func (p *Pager) renderLines() renderedScreen {
+
+	defer util.LogDuration("renderLines")()
+
 	rendered := p.internalRenderLines(true)
 	hasSearchHitLines := false
 	hasNonSearchHitLines := false
@@ -214,11 +221,15 @@ func (p *Pager) internalRenderLines(highlightSearchHitLines bool) renderedScreen
 // lineNumber and numberPrefixLength are required for knowing how much to
 // indent, and to (optionally) render the line number.
 func (p *Pager) renderLine(line reader.NumberedLine, numberPrefixLength int, highlightSearchHitLines bool) []renderedLine {
+	if len(line.Plain()) > 100000 {
+		defer util.LogDuration("renderedLine")()
+	}
+
 	width, _ := p.screen.Size()
 	var wrapped []textstyles.StyledRunesWithTrailer
 	var highlighted textstyles.StyledRunesWithTrailer
 	if p.WrapLongLines {
-		highlighted = line.HighlightedTokens(plainTextStyle, searchHitStyle, p.search, 0)
+		highlighted, _ = line.HighlightedTokens(plainTextStyle, searchHitStyle, p.search, 0)
 
 		wrapped = wrapLine(width-numberPrefixLength, highlighted.StyledRunes)
 	} else {
@@ -228,13 +239,15 @@ func (p *Pager) renderLine(line reader.NumberedLine, numberPrefixLength int, hig
 		//
 		// This is a huge performance gain when dealing with files with
 		// extremeny long lines: https://github.com/walles/moor/issues/358
-		highlighted = line.HighlightedTokens(plainTextStyle, searchHitStyle, p.search, width+p.leftColumnZeroBased+1)
+		highlighted, searchHits := line.HighlightedTokens(
+			plainTextStyle, searchHitStyle, p.search, width+p.leftColumnZeroBased+1)
 
 		// All on one line
 		wrapped = []textstyles.StyledRunesWithTrailer{{
 			StyledRunes:       highlighted.StyledRunes,
 			Trailer:           highlighted.Trailer,
 			ContainsSearchHit: highlighted.ContainsSearchHit,
+			SearchHits:        searchHits,
 		}}
 	}
 
@@ -268,6 +281,7 @@ func (p *Pager) renderLine(line reader.NumberedLine, numberPrefixLength int, hig
 			cells:             decorated,
 			containsSearchHit: subLine.ContainsSearchHit,
 			trailer:           subLine.Trailer,
+			searchHits:        subLine.SearchHits,
 		})
 	}
 

--- a/internal/search/search.go
+++ b/internal/search/search.go
@@ -6,6 +6,8 @@ import (
 	"unicode"
 
 	"github.com/charlievieth/strcase"
+	"github.com/walles/moor/v2/internal/linemetadata"
+	"github.com/walles/moor/v2/internal/util"
 )
 
 type Search struct {
@@ -17,6 +19,8 @@ type Search struct {
 	hasUppercase bool
 
 	pattern *regexp.Regexp
+
+	Cache *SearchCache
 }
 
 func (search Search) Equals(other Search) bool {
@@ -113,9 +117,19 @@ func (search Search) Matches(line string) bool {
 }
 
 // getMatchRanges locates one or more regexp matches in a string
-func (search Search) GetMatchRanges(String string) *MatchRanges {
+func (search Search) GetMatchRanges(String string, idx linemetadata.Index) MatchRanges {
+	if len(String) > 100000 {
+		defer util.LogDuration("GetMatchRanges")()
+	}
+
 	if search.Inactive() {
-		return nil
+		return MatchRanges{}
+	}
+
+	// Check the cache
+	res, pres := search.Cache.Get(idx, search.findMe)
+	if pres {
+		return res
 	}
 
 	if !search.hasUppercase {
@@ -124,9 +138,12 @@ func (search Search) GetMatchRanges(String string) *MatchRanges {
 		String = strings.ToLower(String)
 	}
 
-	return &MatchRanges{
+	res = MatchRanges{
 		Matches: toRunePositions(search.pattern.FindAllStringIndex(String, -1), String),
 	}
+	search.Cache.Set(idx, search.findMe, res)
+
+	return res
 }
 
 // Convert byte indices to rune indices

--- a/internal/search/search_cache.go
+++ b/internal/search/search_cache.go
@@ -1,0 +1,47 @@
+package search
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/walles/moor/v2/internal/linemetadata"
+)
+
+type SearchCache struct {
+	mu sync.Mutex
+
+	cache map[string]MatchRanges
+	idx   int
+}
+
+func (sc *SearchCache) getKey(lineIdx linemetadata.Index, search string) string {
+	return fmt.Sprintf("%v:%v:%v", search, lineIdx, sc.idx)
+}
+
+func (sc *SearchCache) SetReaderIdx(idx int) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	sc.idx = idx
+}
+
+func (sc *SearchCache) Get(lineIdx linemetadata.Index, search string) (MatchRanges, bool) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	res, pres := sc.cache[sc.getKey(lineIdx, search)]
+	return res, pres
+}
+
+func (sc *SearchCache) Set(lineIdx linemetadata.Index, search string, value MatchRanges) {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+
+	sc.cache[sc.getKey(lineIdx, search)] = value
+}
+
+func NewSearchCache() *SearchCache {
+	return &SearchCache{
+		cache: make(map[string]MatchRanges),
+	}
+}

--- a/internal/textstyles/ansiTokenizer.go
+++ b/internal/textstyles/ansiTokenizer.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/walles/moor/v2/internal/linemetadata"
+	"github.com/walles/moor/v2/internal/search"
 	"github.com/walles/moor/v2/twin"
 )
 
@@ -37,6 +38,7 @@ type StyledRunesWithTrailer struct {
 	StyledRunes       []CellWithMetadata
 	Trailer           twin.Style
 	ContainsSearchHit bool
+	SearchHits        search.MatchRanges
 }
 
 func isPlain(s string) bool {

--- a/internal/util/debug.go
+++ b/internal/util/debug.go
@@ -1,0 +1,14 @@
+package util
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+)
+
+func LogDuration(name string) func() {
+	now := time.Now()
+	return func() {
+		log.Debug(name, " ", time.Since(now).String())
+	}
+}


### PR DESCRIPTION
Propagate search.MatchRanges so scrollRightToSearchHits() can go to next match immediately. Previously the code would move right one screen at the time and repeat the search over the entire plain text line, which if the line is large, was extremely slow.

This PR also caches the match hits per line so it can re-highlight the line quickly.