### PR TITLE
Add user-configurable keybindings

### DIFF
--- a/cmd/moor/moor.go
+++ b/cmd/moor/moor.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"runtime"
 	"runtime/debug"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -364,6 +365,59 @@ func noLineNumbersDefault() bool {
 	return false
 }
 
+// appendActionHints writes "Valid actions for [section]: ..." lines to w for
+// every section that appears in an "unknown action" warning. The output is
+// sorted by section name for determinism.
+func appendActionHints(w io.Writer, warnings []internal.ParseWarning) {
+	sectionSet := make(map[string]struct{})
+	for _, warning := range warnings {
+		if strings.HasPrefix(warning.Message, "unknown action") && warning.Section != "" {
+			sectionSet[warning.Section] = struct{}{}
+		}
+	}
+	if len(sectionSet) == 0 {
+		return
+	}
+	sections := make([]string, 0, len(sectionSet))
+	for section := range sectionSet {
+		sections = append(sections, section)
+	}
+	sort.Strings(sections)
+	for _, section := range sections {
+		validActions := internal.GetValidActionNames(section)
+		if len(validActions) > 0 {
+			_, _ = fmt.Fprintf(w, "Valid actions for [%s]: %s\n",
+				section, strings.Join(validActions, ", "))
+		}
+	}
+}
+
+// formatKeybindingsError creates a detailed error message for keybinding issues
+func formatKeybindingsError(filename string, warnings []internal.ParseWarning) error {
+	var errMsg strings.Builder
+	fmt.Fprintf(&errMsg, "invalid keybindings in %s:\n", filename)
+
+	for _, w := range warnings {
+		fmt.Fprintf(&errMsg, "  %s\n", w.Error())
+	}
+
+	fmt.Fprintf(&errMsg, "\n")
+	appendActionHints(&errMsg, warnings)
+	fmt.Fprintf(&errMsg, "\nRun 'moor --print-default-keybindings' to see all available options.\n")
+	return fmt.Errorf("%s", errMsg.String())
+}
+
+// printKeybindingsWarnings prints warnings to stderr for default keybindings path
+func printKeybindingsWarnings(filename string, warnings []internal.ParseWarning) {
+	fmt.Fprintf(os.Stderr, "WARNING: Issues in keybindings file %s:\n", filename)
+	for _, warning := range warnings {
+		fmt.Fprintf(os.Stderr, "  %s\n", warning)
+	}
+	fmt.Fprintf(os.Stderr, "\nContinuing with partial keybindings merged with defaults.\n")
+	appendActionHints(os.Stderr, warnings)
+	fmt.Fprintf(os.Stderr, "Run 'moor --print-default-keybindings' to see all available options.\n\n")
+}
+
 // unescapeManPn removes escaping inserted by GNU man's escape_less function.
 // It escapes ? : . % \ with a backslash.
 func unescapeManPn(manPn string) string {
@@ -405,11 +459,14 @@ func pagerFromArgs(
 	flagSet.SetOutput(io.Discard) // We want to do our own printing
 
 	printVersion := flagSet.Bool("version", false, "Prints the moor version number")
+	printDefaultKeybindings := flagSet.Bool("print-default-keybindings", false, "Print default keybindings to stdout")
+
 	debug := flagSet.Bool("debug", false, "Print debug logs after exiting")
 	trace := flagSet.Bool("trace", false, "Print trace logs after exiting")
 
 	wrap := flagSet.Bool("wrap", false, "Wrap long lines")
 	follow := flagSet.Bool("follow", false, "Follow piped input just like \"tail -f\"")
+	keybindingsPath := flagSet.String("keybindings", "", "Path to custom keybindings `file`")
 	styleOption := flagSetFunc(flagSet,
 		"style", nil,
 		"Highlighting `style` from https://xyproto.github.io/splash/docs/longer/all.html", parseStyleOption)
@@ -500,6 +557,11 @@ func pagerFromArgs(
 		return nil, nil, chroma.Style{}, nil, logsRequested, nil
 	}
 
+	if *printDefaultKeybindings {
+		fmt.Print(internal.DefaultKeybindingsText())
+		return nil, nil, chroma.Style{}, nil, logsRequested, nil
+	}
+
 	log.SetLevel(log.InfoLevel)
 	if *trace {
 		log.SetLevel(log.TraceLevel)
@@ -532,6 +594,53 @@ func pagerFromArgs(
 		if err != nil {
 			return nil, nil, chroma.Style{}, nil, logsRequested, err
 		}
+	}
+
+	// Load and validate custom keybindings BEFORE screen init, so errors are
+	// properly displayed to the user rather than being swallowed by the screen.
+	keybindingsFile := *keybindingsPath
+	explicitKeybindingsPath := keybindingsFile != ""
+	if keybindingsFile == "" {
+		keybindingsFile = internal.DefaultKeybindingsPath()
+	}
+
+	var customBindings *internal.ModeBindings
+	if keybindingsFile != "" {
+		_, err := os.Stat(keybindingsFile)
+		if err == nil {
+			// File exists, try to load it
+			bindings, warnings, parseErr := internal.ParseKeybindingsFile(keybindingsFile)
+			if parseErr != nil {
+				if explicitKeybindingsPath {
+					// User explicitly specified the file, treat as error
+					return nil, nil, chroma.Style{}, nil, false, fmt.Errorf("failed to load keybindings from %s: %w", keybindingsFile, parseErr)
+				}
+				log.Warnf("Failed to load keybindings from %s: %v", keybindingsFile, parseErr)
+			} else if len(warnings) > 0 {
+				// Format warnings nicely
+				if explicitKeybindingsPath {
+					// User explicitly specified the file, treat warnings as errors
+					return nil, nil, chroma.Style{}, nil, false, formatKeybindingsError(keybindingsFile, warnings)
+				}
+				// Default path: print warnings but continue
+				printKeybindingsWarnings(keybindingsFile, warnings)
+				customBindings = &bindings
+				log.Infof("Loaded keybindings from %s with %d warnings", keybindingsFile, len(warnings))
+			} else {
+				customBindings = &bindings
+				log.Debugf("Loaded keybindings from %s", keybindingsFile)
+			}
+		} else if !os.IsNotExist(err) {
+			// File check failed for some reason other than not existing
+			if explicitKeybindingsPath {
+				return nil, nil, chroma.Style{}, nil, false, fmt.Errorf("failed to check keybindings file %s: %w", keybindingsFile, err)
+			}
+			log.Warnf("Failed to check keybindings file %s: %v", keybindingsFile, err)
+		} else if explicitKeybindingsPath {
+			// User specified a file that doesn't exist
+			return nil, nil, chroma.Style{}, nil, false, fmt.Errorf("keybindings file not found: %s", keybindingsFile)
+		}
+		// If file doesn't exist and it's the default path, that's fine - we'll use defaults (already set in NewPager)
 	}
 
 	if len(flagSetArgs) == 0 && !stdinIsRedirected {
@@ -656,6 +765,11 @@ func pagerFromArgs(
 	if *follow && pager.TargetLine == nil {
 		reallyHigh := linemetadata.IndexMax()
 		pager.TargetLine = &reallyHigh
+	}
+
+	// Apply custom keybindings if they were loaded earlier
+	if customBindings != nil {
+		pager.ModeBindings = *customBindings
 	}
 
 	return pager, screen, style, &formatter, logsRequested, nil

--- a/internal/inputbox.go
+++ b/internal/inputbox.go
@@ -29,9 +29,22 @@ type InputBox struct {
 	// onTextChanged is an optional callback which is triggered when the text
 	// of the InputBox changes.
 	onTextChanged InputBoxOnTextChanged
+
+	// bindings holds the key bindings for input operations
+	bindings KeyBindings[InputAction]
 }
 
-// draw renders the input box at the bottom line of the screen, showing a
+// NewInputBox creates an InputBox with the given accept mode and key bindings.
+// Prefer this over a struct literal: omitting bindings causes handleKey and
+// handleRune to silently do nothing for any bound action.
+func NewInputBox(accept AcceptMode, bindings KeyBindings[InputAction]) *InputBox {
+	return &InputBox{
+		accept:   accept,
+		bindings: bindings,
+	}
+}
+
+// draw renders the input box at the bottom line of the screen
 // simple prompt and the current text with a reverse attribute cursor.
 func (b *InputBox) draw(screen twin.Screen, keys_help string, prompt string) {
 	width, height := screen.Size()
@@ -104,43 +117,14 @@ func (b *InputBox) setText(text string) {
 }
 
 // handleRune appends runes to the text of the InputBox and returns if those have been processed.
-// (Some keyboards send 0x08 instead of backspace, so we support it here too).
 func (b *InputBox) handleRune(char rune) bool {
-	if char == '\x08' {
-		b.backspace()
-		return true
-	}
-	if char == '\x01' {
-		// Ctrl-A, move cursor to start
-		b.moveCursorHome()
-		return true
-	}
-	if char == '\x05' {
-		// Ctrl-E, move cursor to end
-		b.moveCursorEnd()
-		return true
-	}
-	if char == '\x02' {
-		// Ctrl-B, move cursor left
-		b.moveCursorLeft()
-		return true
-	}
-	if char == '\x06' {
-		// Ctrl-F, move cursor right
-		b.moveCursorRight()
-		return true
-	}
-	if char == '\x0b' {
-		// Ctrl-K, delete to end of line
-		b.deleteToEnd()
-		return true
-	}
-	if char == '\x15' {
-		// Ctrl-U, delete to start of line
-		b.deleteToStart()
+	// Check if there's a binding for this rune
+	if action, found := b.bindings.RuneBindings[char]; found {
+		b.executeInputAction(action)
 		return true
 	}
 
+	// Fallthrough: insert character
 	// If configured to accept numbers only, drop any non-digit rune.
 	if b.accept == INPUTBOX_ACCEPT_POSITIVE_NUMBERS {
 		if !unicode.IsDigit(char) {
@@ -177,32 +161,10 @@ func (b *InputBox) handleRune(char rune) bool {
 // handleKey processes special keys like backspace, delete, arrow keys, home and end.
 // Returns true if the key was processed, false otherwise.
 func (b *InputBox) handleKey(key twin.KeyCode) bool {
-	switch key {
-	case twin.KeyLeft:
-		b.moveCursorLeft()
-		return true
-
-	case twin.KeyRight:
-		b.moveCursorRight()
-		return true
-
-	case twin.KeyHome:
-		b.moveCursorHome()
-		return true
-
-	case twin.KeyEnd:
-		b.moveCursorEnd()
-		return true
-
-	case twin.KeyBackspace:
-		b.backspace()
-		return true
-
-	case twin.KeyDelete:
-		b.delete()
+	if action, found := b.bindings.KeyCodeBindings[key]; found {
+		b.executeInputAction(action)
 		return true
 	}
-
 	return false
 }
 
@@ -267,5 +229,29 @@ func (b *InputBox) delete() {
 		if b.onTextChanged != nil {
 			b.onTextChanged(b.text)
 		}
+	}
+}
+
+// executeInputAction executes the given input action
+func (b *InputBox) executeInputAction(action InputAction) {
+	switch action {
+	case NoInputAction:
+		return
+	case CursorLeft:
+		b.moveCursorLeft()
+	case CursorRight:
+		b.moveCursorRight()
+	case CursorHome:
+		b.moveCursorHome()
+	case CursorEnd:
+		b.moveCursorEnd()
+	case Backspace:
+		b.backspace()
+	case Delete:
+		b.delete()
+	case DeleteToEnd:
+		b.deleteToEnd()
+	case DeleteToStart:
+		b.deleteToStart()
 	}
 }

--- a/internal/inputbox_test.go
+++ b/internal/inputbox_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestInsertAndBackspace(t *testing.T) {
 	screen := twin.NewFakeScreen(40, 2)
-	b := &InputBox{accept: INPUTBOX_ACCEPT_ALL}
+	b := NewInputBox(INPUTBOX_ACCEPT_ALL, DefaultModeBindings().Input)
 
 	assert.Assert(t, b.handleRune('a'))
 	assert.Assert(t, b.handleRune('b'))
@@ -28,7 +28,7 @@ func TestInsertAndBackspace(t *testing.T) {
 
 func TestCursorMovementAndInsertDelete(t *testing.T) {
 	screen := twin.NewFakeScreen(80, 2)
-	b := &InputBox{accept: INPUTBOX_ACCEPT_ALL}
+	b := NewInputBox(INPUTBOX_ACCEPT_ALL, DefaultModeBindings().Input)
 	b.handleRune('a')
 	b.handleRune('b')
 	b.handleRune('c')
@@ -59,8 +59,22 @@ func TestCursorMovementAndInsertDelete(t *testing.T) {
 	assert.Equal(t, "G: SaXcE", row)
 }
 
+func TestCtrlHBackspace(t *testing.T) {
+	// Some keyboards/terminals send 0x08 (ctrl-h) instead of the backspace key.
+	// Regression test: handleRune('\x08') must behave identically to a real backspace.
+	b := NewInputBox(INPUTBOX_ACCEPT_ALL, DefaultModeBindings().Input)
+
+	assert.Assert(t, b.handleRune('x'))
+	assert.Assert(t, b.handleRune('y'))
+	assert.Equal(t, "xy", b.text)
+
+	// ctrl-h should delete the last character
+	assert.Assert(t, b.handleRune('\x08'))
+	assert.Equal(t, "x", b.text)
+}
+
 func TestAcceptPositiveNumbers(t *testing.T) {
-	b := &InputBox{accept: INPUTBOX_ACCEPT_POSITIVE_NUMBERS}
+	b := NewInputBox(INPUTBOX_ACCEPT_POSITIVE_NUMBERS, DefaultModeBindings().Input)
 	assert.Assert(t, b.handleRune('1'))
 	assert.Assert(t, !b.handleRune('a'))
 	assert.Assert(t, b.handleRune('2'))
@@ -69,7 +83,7 @@ func TestAcceptPositiveNumbers(t *testing.T) {
 
 func TestUnicodeRunes(t *testing.T) {
 	screen := twin.NewFakeScreen(80, 2)
-	b := &InputBox{accept: INPUTBOX_ACCEPT_ALL}
+	b := NewInputBox(INPUTBOX_ACCEPT_ALL, DefaultModeBindings().Input)
 	// Insert a CJK char and an emoji
 	assert.Assert(t, b.handleRune('午'))
 	assert.Assert(t, b.handleRune('🧐'))

--- a/internal/keybindings.go
+++ b/internal/keybindings.go
@@ -1,0 +1,663 @@
+package internal
+
+import (
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/walles/moor/v2/twin"
+)
+
+// Action represents actions available across all modes
+type Action int
+
+const (
+	NoAction Action = iota
+	// Navigation
+	Quit
+	Reload
+	Edit
+	Help
+	ToggleStatusBar
+	ScrollUp
+	ScrollDown
+	ScrollLeft
+	ScrollRight
+	ScrollLeft1
+	ScrollRight1
+	ScrollTop
+	ScrollBottom
+	ScrollHome
+	ScrollPageUp
+	ScrollPageDown
+	ScrollHalfPageUp
+	ScrollHalfPageDown
+	// Search
+	SearchForward
+	SearchBackward
+	NextSearchHit
+	PreviousSearchHit
+	// Modes
+	Filter
+	GotoLine
+	ColonCommand
+	Mark
+	JumpToMark
+	// Display
+	ToggleWrap
+	CycleTabSize
+	// Input modes
+	Accept
+	Cancel
+	HistoryPrevious
+	HistoryNext
+	// Goto specific
+	GotoTop
+	// Colon command specific
+	NextFile
+	PreviousFile
+	FirstFile
+)
+
+// InputAction represents actions available for input box editing
+type InputAction int
+
+const (
+	NoInputAction InputAction = iota
+	CursorLeft
+	CursorRight
+	CursorHome
+	CursorEnd
+	Backspace
+	Delete
+	DeleteToEnd
+	DeleteToStart
+)
+
+// KeyBindings holds the key bindings for a specific mode
+type KeyBindings[A any] struct {
+	KeyCodeBindings map[twin.KeyCode]A
+	RuneBindings    map[rune]A
+}
+
+// ModeBindings holds key bindings for all modes
+type ModeBindings struct {
+	Viewing      KeyBindings[Action]
+	NotFound     KeyBindings[Action]
+	Search       KeyBindings[Action]
+	Filter       KeyBindings[Action]
+	GotoLine     KeyBindings[Action]
+	ColonCommand KeyBindings[Action]
+	Mark         KeyBindings[Action]
+	JumpToMark   KeyBindings[Action]
+	Input        KeyBindings[InputAction]
+}
+
+// bindingEntry represents a single key-to-action binding
+type bindingEntry[A any] struct {
+	key    string
+	action A
+}
+
+// Action name tables
+var actionNames = map[Action]string{
+	NoAction:           "noaction",
+	Quit:               "quit",
+	Reload:             "reload",
+	Edit:               "edit",
+	Help:               "help",
+	ToggleStatusBar:    "toggle-statusbar",
+	ScrollUp:           "scroll-up",
+	ScrollDown:         "scroll-down",
+	ScrollTop:          "scroll-top",
+	ScrollBottom:       "scroll-bottom",
+	ScrollPageDown:     "scroll-page-down",
+	ScrollPageUp:       "scroll-page-up",
+	ScrollHalfPageDown: "scroll-half-page-down",
+	ScrollHalfPageUp:   "scroll-half-page-up",
+	ScrollRight:        "scroll-right",
+	ScrollLeft:         "scroll-left",
+	ScrollRight1:       "scroll-right-1",
+	ScrollLeft1:        "scroll-left-1",
+	SearchForward:      "search-forward",
+	SearchBackward:     "search-backward",
+	Filter:             "filter",
+	GotoLine:           "goto-line",
+	ColonCommand:       "colon-command",
+	NextSearchHit:      "next-search-hit",
+	PreviousSearchHit:  "previous-search-hit",
+	Mark:               "mark",
+	JumpToMark:         "jump-to-mark",
+	ToggleWrap:         "toggle-wrap",
+	CycleTabSize:       "cycle-tab-size",
+	ScrollHome:         "scroll-home",
+	Accept:             "accept",
+	Cancel:             "cancel",
+	HistoryPrevious:    "history-previous",
+	HistoryNext:        "history-next",
+	GotoTop:            "goto-top",
+	NextFile:           "next-file",
+	PreviousFile:       "previous-file",
+	FirstFile:          "first-file",
+}
+
+// Input action name tables
+var inputActionNames = map[InputAction]string{
+	NoInputAction: "noaction",
+	CursorLeft:    "cursor-left",
+	CursorRight:   "cursor-right",
+	CursorHome:    "cursor-home",
+	CursorEnd:     "cursor-end",
+	Backspace:     "backspace",
+	Delete:        "delete",
+	DeleteToEnd:   "delete-to-end",
+	DeleteToStart: "delete-to-start",
+}
+
+// Reverse maps (built lazily)
+var (
+	actionNamesReverse      map[string]Action
+	inputActionNamesReverse map[string]InputAction
+	reverseMapOnce          sync.Once
+)
+
+func buildReverseMaps() {
+	actionNamesReverse = make(map[string]Action)
+	for action, name := range actionNames {
+		actionNamesReverse[name] = action
+	}
+
+	inputActionNamesReverse = make(map[string]InputAction)
+	for action, name := range inputActionNames {
+		inputActionNamesReverse[name] = action
+	}
+}
+
+// commonActions is derived from the keys of commonActionHandlers and lists
+// every Action that is common across all modes, excluding NoAction.
+var commonActions = func() []Action {
+	actions := make([]Action, 0, len(commonActionHandlers))
+	for a := range commonActionHandlers {
+		actions = append(actions, a)
+	}
+	return actions
+}()
+
+// GetValidActionNames returns a sorted list of valid action names for a given
+// section, derived from that section's default entries plus any actions it
+// inherits at runtime (common actions or all viewing actions).
+func GetValidActionNames(section string) []string {
+	// actionsFrom extracts the Action values from a slice of binding entries.
+	actionsFrom := func(entries []bindingEntry[Action]) []Action {
+		actions := make([]Action, len(entries))
+		for i, e := range entries {
+			actions[i] = e.action
+		}
+		return actions
+	}
+
+	// collect deduplicates action names across one or more Action slices,
+	// skips "noaction", and returns the result sorted.
+	collect := func(groups ...[]Action) []string {
+		seen := make(map[Action]bool)
+		var names []string
+		for _, group := range groups {
+			for _, a := range group {
+				if seen[a] {
+					continue
+				}
+				seen[a] = true
+				if name, ok := actionNames[a]; ok && name != "noaction" {
+					names = append(names, name)
+				}
+			}
+		}
+		sort.Strings(names)
+		return names
+	}
+
+	for _, s := range actionSections {
+		if section == s.name {
+			return collect(actionsFrom(s.entries), actionsFrom(s.inherits), commonActions)
+		}
+	}
+
+	if section == "input" {
+		// Input uses a separate action type; no commonActions apply.
+		seen := make(map[InputAction]bool)
+		var names []string
+		for _, entry := range defaultInputEntries {
+			if seen[entry.action] {
+				continue
+			}
+			seen[entry.action] = true
+			if name, ok := inputActionNames[entry.action]; ok && name != "noaction" {
+				names = append(names, name)
+			}
+		}
+		sort.Strings(names)
+		return names
+	}
+
+	return nil
+}
+
+// Default bindings - source of truth
+var defaultViewingEntries = []bindingEntry[Action]{
+	{"escape", Quit},
+	{"q", Quit},
+	{"r", Reload},
+	{"v", Edit},
+	{"h", Help},
+	{"=", ToggleStatusBar},
+	{"k", ScrollUp},
+	{"y", ScrollUp},
+	{"ctrl-p", ScrollUp},
+	{"up", ScrollUp},
+	{"j", ScrollDown},
+	{"e", ScrollDown},
+	{"ctrl-n", ScrollDown},
+	{"down", ScrollDown},
+	{"enter", ScrollDown},
+	{"<", ScrollTop},
+	{"home", ScrollTop},
+	{">", ScrollBottom},
+	{"G", ScrollBottom},
+	{"end", ScrollBottom},
+	{"f", ScrollPageDown},
+	{"space", ScrollPageDown},
+	{"ctrl-f", ScrollPageDown},
+	{"pagedown", ScrollPageDown},
+	{"b", ScrollPageUp},
+	{"ctrl-b", ScrollPageUp},
+	{"pageup", ScrollPageUp},
+	{"u", ScrollHalfPageUp},
+	{"ctrl-u", ScrollHalfPageUp},
+	{"d", ScrollHalfPageDown},
+	{"ctrl-d", ScrollHalfPageDown},
+	{"right", ScrollRight},
+	{"left", ScrollLeft},
+	{"alt-right", ScrollRight1},
+	{"alt-left", ScrollLeft1},
+	{"/", SearchForward},
+	{"?", SearchBackward},
+	{"&", Filter},
+	{"g", GotoLine},
+	{":", ColonCommand},
+	{"n", NextSearchHit},
+	{"p", PreviousSearchHit},
+	{"N", PreviousSearchHit},
+	{"m", Mark},
+	{"'", JumpToMark},
+	{"w", ToggleWrap},
+	{"ctrl-t", CycleTabSize},
+	{"ctrl-a", ScrollHome},
+}
+
+var defaultNotFoundEntries = []bindingEntry[Action]{
+	{"escape", Cancel},
+}
+
+var defaultSearchEntries = []bindingEntry[Action]{
+	{"enter", Accept},
+	{"escape", Cancel},
+	{"ctrl-c", Cancel},
+	{"up", HistoryPrevious},
+	{"down", HistoryNext},
+	{"pageup", ScrollPageUp},
+	{"pagedown", ScrollPageDown},
+}
+
+var defaultFilterEntries = []bindingEntry[Action]{
+	{"enter", Accept},
+	{"escape", Cancel},
+	{"up", ScrollUp},
+	{"down", ScrollDown},
+	{"pageup", ScrollPageUp},
+	{"pagedown", ScrollPageDown},
+}
+
+var defaultGotoLineEntries = []bindingEntry[Action]{
+	{"enter", Accept},
+	{"escape", Cancel},
+	{"g", GotoTop},
+	{"q", Cancel},
+}
+
+var defaultColonCommandEntries = []bindingEntry[Action]{
+	{"escape", Cancel},
+	{"q", Cancel},
+	{"n", NextFile},
+	{"p", PreviousFile},
+	{"x", FirstFile},
+}
+
+var defaultMarkEntries = []bindingEntry[Action]{
+	{"escape", Cancel},
+}
+
+var defaultJumpToMarkEntries = []bindingEntry[Action]{
+	{"enter", Cancel},
+	{"escape", Cancel},
+}
+
+// sectionInfo ties a section name to its default Action entries and a pointer
+// accessor for the corresponding field in ModeBindings.  This is the single
+// source of truth for the section-name → entries mapping
+type sectionInfo struct {
+	name     string
+	entries  []bindingEntry[Action]
+	field    func(*ModeBindings) *KeyBindings[Action]
+	inherits []bindingEntry[Action] // runtime fallback entries whose actions are also valid here
+}
+
+// actionSections is the ordered list of all non-input sections.
+var actionSections = []sectionInfo{
+	{"viewing", defaultViewingEntries, func(mb *ModeBindings) *KeyBindings[Action] { return &mb.Viewing }, nil},
+	{"not-found", defaultNotFoundEntries, func(mb *ModeBindings) *KeyBindings[Action] { return &mb.NotFound }, defaultViewingEntries},
+	{"search", defaultSearchEntries, func(mb *ModeBindings) *KeyBindings[Action] { return &mb.Search }, nil},
+	{"filter", defaultFilterEntries, func(mb *ModeBindings) *KeyBindings[Action] { return &mb.Filter }, nil},
+	{"goto-line", defaultGotoLineEntries, func(mb *ModeBindings) *KeyBindings[Action] { return &mb.GotoLine }, nil},
+	{"colon-command", defaultColonCommandEntries, func(mb *ModeBindings) *KeyBindings[Action] { return &mb.ColonCommand }, nil},
+	{"mark", defaultMarkEntries, func(mb *ModeBindings) *KeyBindings[Action] { return &mb.Mark }, nil},
+	{"jump-to-mark", defaultJumpToMarkEntries, func(mb *ModeBindings) *KeyBindings[Action] { return &mb.JumpToMark }, nil},
+}
+
+var defaultInputEntries = []bindingEntry[InputAction]{
+	{"left", CursorLeft},
+	{"right", CursorRight},
+	{"home", CursorHome},
+	{"end", CursorEnd},
+	{"backspace", Backspace},
+	{"ctrl-h", Backspace}, // Some keyboards/terminals send 0x08 instead of backspace
+	{"delete", Delete},
+	{"ctrl-a", CursorHome},
+	{"ctrl-e", CursorEnd},
+	{"ctrl-b", CursorLeft},
+	{"ctrl-f", CursorRight},
+	{"ctrl-k", DeleteToEnd},
+	{"ctrl-u", DeleteToStart},
+}
+
+var (
+	defaultModeBindingsCache *ModeBindings
+	defaultModeBindingsOnce  sync.Once
+)
+
+// DefaultModeBindings returns the default key bindings for all modes
+func DefaultModeBindings() ModeBindings {
+	defaultModeBindingsOnce.Do(func() {
+		bindings := ModeBindings{
+			Input: buildKeyBindings(defaultInputEntries),
+		}
+		for _, s := range actionSections {
+			*s.field(&bindings) = buildKeyBindings(s.entries)
+		}
+		defaultModeBindingsCache = &bindings
+	})
+	result := ModeBindings{
+		Input: cloneKeyBindings(defaultModeBindingsCache.Input),
+	}
+	for _, s := range actionSections {
+		*s.field(&result) = cloneKeyBindings(*s.field(defaultModeBindingsCache))
+	}
+	return result
+}
+
+// EmptyModeBindings returns a ModeBindings where every section has empty
+// (non-nil) maps and no bindings.  It is the counterpart of DefaultModeBindings
+// and is used, for example, to implement the !clear directive in keybinding
+// files.
+func EmptyModeBindings() ModeBindings {
+	mb := ModeBindings{
+		Input: emptyKeyBindings[InputAction](),
+	}
+	for _, s := range actionSections {
+		*s.field(&mb) = emptyKeyBindings[Action]()
+	}
+	return mb
+}
+
+// emptyKeyBindings returns a KeyBindings with empty, non-nil maps.
+func emptyKeyBindings[A any]() KeyBindings[A] {
+	return KeyBindings[A]{
+		KeyCodeBindings: make(map[twin.KeyCode]A),
+		RuneBindings:    make(map[rune]A),
+	}
+}
+
+// cloneKeyBindings returns a shallow copy of kb with independently cloned maps,
+// so callers cannot mutate the shared cache.
+func cloneKeyBindings[A any](kb KeyBindings[A]) KeyBindings[A] {
+	return KeyBindings[A]{
+		KeyCodeBindings: maps.Clone(kb.KeyCodeBindings),
+		RuneBindings:    maps.Clone(kb.RuneBindings),
+	}
+}
+
+// buildKeyBindings converts a slice of binding entries to KeyBindings
+func buildKeyBindings[A any](entries []bindingEntry[A]) KeyBindings[A] {
+	kb := KeyBindings[A]{
+		KeyCodeBindings: make(map[twin.KeyCode]A),
+		RuneBindings:    make(map[rune]A),
+	}
+
+	for _, entry := range entries {
+		keyCode, isKeyCode := parseKeyCodeName(entry.key)
+		if isKeyCode {
+			kb.KeyCodeBindings[keyCode] = entry.action
+			continue
+		}
+
+		r, isRune := parseRuneKeyName(entry.key)
+		if isRune {
+			kb.RuneBindings[r] = entry.action
+			continue
+		}
+
+		// This should never happen with valid default entries
+		panic(fmt.Sprintf("Invalid key name in defaults: %q", entry.key))
+	}
+
+	return kb
+}
+
+var keyCodeByName = map[string]twin.KeyCode{
+	"escape":    twin.KeyEscape,
+	"enter":     twin.KeyEnter,
+	"backspace": twin.KeyBackspace,
+	"delete":    twin.KeyDelete,
+	"up":        twin.KeyUp,
+	"down":      twin.KeyDown,
+	"left":      twin.KeyLeft,
+	"right":     twin.KeyRight,
+	"home":      twin.KeyHome,
+	"end":       twin.KeyEnd,
+	"pageup":    twin.KeyPgUp,
+	"pgup":      twin.KeyPgUp,
+	"pagedown":  twin.KeyPgDown,
+	"pgdown":    twin.KeyPgDown,
+	"alt-up":    twin.KeyAltUp,
+	"alt-down":  twin.KeyAltDown,
+	"alt-left":  twin.KeyAltLeft,
+	"alt-right": twin.KeyAltRight,
+}
+
+func parseKeyCodeName(name string) (twin.KeyCode, bool) {
+	lower := strings.ToLower(name)
+	kc, ok := keyCodeByName[lower]
+	return kc, ok
+}
+
+// parseRuneKeyName parses a key name into a rune
+func parseRuneKeyName(name string) (rune, bool) {
+	// Control characters: ctrl-a through ctrl-z (lowercase only)
+	if strings.HasPrefix(name, "ctrl-") && len(name) == 6 {
+		ch := name[5] // Character after "ctrl-"
+		if ch >= 'a' && ch <= 'z' {
+			return rune(ch - 'a' + 1), true
+		}
+	}
+
+	// Special rune names (case-insensitive for convenience)
+	var runeByName = map[string]rune{
+		"space": ' ',
+		"tab":   '\t',
+		"\\t":   '\t',
+		"\\n":   '\n',
+	}
+	lower := strings.ToLower(name)
+	if r, ok := runeByName[lower]; ok {
+		return r, true
+	}
+
+	// Single character
+	runes := []rune(name)
+	if len(runes) == 1 {
+		return runes[0], true
+	}
+
+	return 0, false
+}
+
+// serializeSection converts a slice of bindings to text format
+func serializeSection[A comparable](entries []bindingEntry[A], actionNames map[A]string) string {
+	var result strings.Builder
+
+	maxKeyLen := 0
+	for _, entry := range entries {
+		if len(entry.key) > maxKeyLen {
+			maxKeyLen = len(entry.key)
+		}
+	}
+
+	for _, entry := range entries {
+		actionName := actionNames[entry.action]
+		padding := strings.Repeat(" ", maxKeyLen-len(entry.key)+2)
+		fmt.Fprintf(&result, "%s%s%s\n", entry.key, padding, actionName)
+	}
+
+	return result.String()
+}
+
+// DefaultKeybindingsText returns the default keybindings as a text file
+func DefaultKeybindingsText() string {
+	var result strings.Builder
+
+	result.WriteString("# Keybindings for moor\n")
+	result.WriteString("# Lines starting with # are comments. Blank lines are ignored.\n")
+	result.WriteString("# Format: <key>  <action>\n")
+	result.WriteString("#\n")
+	result.WriteString("# Modifiers: alt-up, alt-down, alt-left, alt-right\n")
+	result.WriteString("# Control:   ctrl-a through ctrl-z (lowercase only, e.g., ctrl-d, ctrl-u)\n")
+	result.WriteString("# Special:   escape, enter, backspace, delete, up, down, left, right,\n")
+	result.WriteString("#            home, end, pageup, pagedown\n")
+	result.WriteString("# Letters:   Case-sensitive ('a' is different from 'A')\n")
+	result.WriteString("# Space:     space\n")
+	result.WriteString("#\n")
+	result.WriteString("# Use 'noaction' to disable a key binding\n")
+	result.WriteString("\n")
+
+	result.WriteString("# Clears the current key bindings\n")
+	result.WriteString("!clear\n")
+	result.WriteString("\n")
+
+	for _, s := range actionSections {
+		result.WriteString("[" + s.name + "]\n")
+		result.WriteString(serializeSection(s.entries, actionNames))
+		result.WriteString("\n")
+	}
+
+	result.WriteString("[input]\n")
+	result.WriteString(serializeSection(defaultInputEntries, inputActionNames))
+
+	return result.String()
+}
+
+// keyForAction returns a human-readable key name for the first key bound to the
+// given action in kb. Rune bindings are preferred over key-code bindings because
+// they produce shorter, more legible labels (e.g. "n" instead of "enter").
+// When multiple keys share the same action the result is the lexicographically
+// smallest match, so the output is deterministic. Returns "?" when no binding
+// is found.
+func keyForAction(kb KeyBindings[Action], action Action) string {
+	// Collect matching key-code keys, sort for determinism.
+	var names []string
+	for kc, a := range kb.KeyCodeBindings {
+		if a == action {
+			names = append(names, keyCodeDisplayName(kc))
+		}
+	}
+	if len(names) > 0 {
+		sort.Strings(names)
+		return names[0]
+	}
+
+	// Collect matching rune keys, sort for determinism.
+	var runes []rune
+	for r, a := range kb.RuneBindings {
+		if a == action {
+			runes = append(runes, r)
+		}
+	}
+	if len(runes) > 0 {
+		sort.Slice(runes, func(i, j int) bool {
+			return runeDisplayName(runes[i]) < runeDisplayName(runes[j])
+		})
+		return runeDisplayName(runes[0])
+	}
+
+	return "?"
+}
+
+// runeDisplayName returns a short, human-readable label for a rune key.
+func runeDisplayName(r rune) string {
+	// Check named specials before the ctrl range so that e.g. tab (rune 9)
+	// is shown as "tab" rather than "ctrl-i".
+	switch r {
+	case ' ':
+		return "space"
+	case '\t':
+		return "tab"
+	}
+	if r >= 1 && r <= 26 {
+		return fmt.Sprintf("ctrl-%c", 'a'+r-1)
+	}
+	return string(r)
+}
+
+// keyCodeDisplayName returns a human-readable label for a KeyCode by
+// reverse-looking up keyCodeByName. Falls back to a numeric representation.
+func keyCodeDisplayName(kc twin.KeyCode) string {
+	// Prefer the shorter / more canonical name when multiple aliases exist.
+	best := ""
+	for name, code := range keyCodeByName {
+		if code == kc {
+			if best == "" || len(name) < len(best) || (len(name) == len(best) && name < best) {
+				best = name
+			}
+		}
+	}
+	if best != "" {
+		return best
+	}
+	return fmt.Sprintf("key(%d)", kc)
+}
+
+// DefaultKeybindingsPath returns the default path for the keybindings file
+func DefaultKeybindingsPath() string {
+	configHome := os.Getenv("XDG_CONFIG_HOME")
+	if configHome == "" {
+		home := os.Getenv("HOME")
+		if home == "" {
+			// Fallback if HOME is not set (unlikely on Unix systems)
+			return ""
+		}
+		configHome = filepath.Join(home, ".config")
+	}
+	return filepath.Join(configHome, "moor", "keybindings")
+}

--- a/internal/keybindings_parser.go
+++ b/internal/keybindings_parser.go
@@ -1,0 +1,140 @@
+package internal
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ParseWarning represents a non-fatal issue found while parsing a keybindings
+// file. The structured fields let callers act on the warning without parsing
+// the human-readable message string.
+type ParseWarning struct {
+	Line    int
+	Section string // section name like "viewing", or "" if outside any section
+	Message string
+}
+
+// Error implements the error interface so ParseWarning can be used wherever an
+// error is expected, and so that existing code calling .Error() keeps working.
+func (w ParseWarning) Error() string {
+	return fmt.Sprintf("line %d: %s", w.Line, w.Message)
+}
+
+// ParseKeybindingsFile parses a keybindings file and returns the resulting
+// bindings.  The file is overlaid on top of the defaults: every key the user
+// lists overrides the default for that key, and all other defaults are kept.
+// The special directive !clear (anywhere in the file) resets every section to
+// empty before processing continues, giving a clean-slate starting point.
+func ParseKeybindingsFile(path string) (ModeBindings, []ParseWarning, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return ModeBindings{}, nil, err
+	}
+	defer func() { _ = file.Close() }()
+
+	// Ensure reverse maps are built
+	reverseMapOnce.Do(buildReverseMaps)
+
+	result := DefaultModeBindings()
+	var warnings []ParseWarning
+	var currentSection string
+
+	// buildSectionBindings returns a fresh map pointing into the current result.
+	// It must be called whenever result is replaced (e.g. on !clear).
+	buildSectionBindings := func() map[string]*KeyBindings[Action] {
+		m := make(map[string]*KeyBindings[Action], len(actionSections))
+		for _, s := range actionSections {
+			m[s.name] = s.field(&result)
+		}
+		return m
+	}
+	sectionBindings := buildSectionBindings()
+
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip comments and blank lines
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Section header
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			sectionName := strings.TrimSpace(line[1 : len(line)-1])
+			currentSection = sectionName
+			_, isActionSection := sectionBindings[sectionName]
+			if !isActionSection && sectionName != "input" {
+				warnings = append(warnings, ParseWarning{Line: lineNum, Section: "", Message: fmt.Sprintf("unknown section [%s]", sectionName)})
+			}
+			continue
+		}
+
+		// !clear resets every section to empty; typically at the top of the file.
+		if line == "!clear" {
+			result = EmptyModeBindings()
+			sectionBindings = buildSectionBindings()
+			continue
+		}
+
+		if currentSection == "" {
+			warnings = append(warnings, ParseWarning{Line: lineNum, Section: "", Message: "binding outside of section"})
+			continue
+		}
+
+		// Split into key and action
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			warnings = append(warnings, ParseWarning{Line: lineNum, Section: currentSection, Message: fmt.Sprintf("expected 2 fields (key action), got %d", len(fields))})
+			continue
+		}
+
+		keyName := fields[0]
+		actionName := strings.ToLower(fields[1])
+
+		// Parse the key
+		keyCode, isKeyCode := parseKeyCodeName(keyName)
+		r, isRune := parseRuneKeyName(keyName)
+
+		if !isKeyCode && !isRune {
+			warnings = append(warnings, ParseWarning{Line: lineNum, Section: currentSection, Message: fmt.Sprintf("unknown key name %q", keyName)})
+			continue
+		}
+
+		if kb, ok := sectionBindings[currentSection]; ok {
+			action, ok := actionNamesReverse[actionName]
+			if !ok {
+				warnings = append(warnings, ParseWarning{Line: lineNum, Section: currentSection, Message: fmt.Sprintf("unknown action %q", actionName)})
+				continue
+			}
+			if isKeyCode {
+				kb.KeyCodeBindings[keyCode] = action
+			} else {
+				kb.RuneBindings[r] = action
+			}
+		} else if currentSection == "input" {
+			action, ok := inputActionNamesReverse[actionName]
+			if !ok {
+				warnings = append(warnings, ParseWarning{Line: lineNum, Section: currentSection, Message: fmt.Sprintf("unknown action %q", actionName)})
+				continue
+			}
+			if isKeyCode {
+				result.Input.KeyCodeBindings[keyCode] = action
+			} else {
+				result.Input.RuneBindings[r] = action
+			}
+		}
+		// unknown sections: silently skip (already warned about the section header)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return ModeBindings{}, warnings, err
+	}
+
+	return result, warnings, nil
+}

--- a/internal/keybindings_test.go
+++ b/internal/keybindings_test.go
@@ -1,0 +1,1310 @@
+package internal
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/walles/moor/v2/twin"
+)
+
+// TestParseKeyCodeName tests parsing of special key names
+func TestParseKeyCodeName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected twin.KeyCode
+		valid    bool
+	}{
+		// Standard special keys
+		{"escape", "escape", twin.KeyEscape, true},
+		{"enter", "enter", twin.KeyEnter, true},
+		{"backspace", "backspace", twin.KeyBackspace, true},
+		{"delete", "delete", twin.KeyDelete, true},
+		{"up", "up", twin.KeyUp, true},
+		{"down", "down", twin.KeyDown, true},
+		{"left", "left", twin.KeyLeft, true},
+		{"right", "right", twin.KeyRight, true},
+		{"home", "home", twin.KeyHome, true},
+		{"end", "end", twin.KeyEnd, true},
+		{"pageup", "pageup", twin.KeyPgUp, true},
+		{"pagedown", "pagedown", twin.KeyPgDown, true},
+		{"pgup", "pgup", twin.KeyPgUp, true},
+		{"pgdown", "pgdown", twin.KeyPgDown, true},
+
+		// Alt-modified keys
+		{"alt-up", "alt-up", twin.KeyAltUp, true},
+		{"alt-down", "alt-down", twin.KeyAltDown, true},
+		{"alt-left", "alt-left", twin.KeyAltLeft, true},
+		{"alt-right", "alt-right", twin.KeyAltRight, true},
+
+		// Case insensitivity
+		{"ESCAPE", "ESCAPE", twin.KeyEscape, true},
+		{"EsCaPe", "EsCaPe", twin.KeyEscape, true},
+		{"ALT-UP", "ALT-UP", twin.KeyAltUp, true},
+		{"Alt-Up", "Alt-Up", twin.KeyAltUp, true},
+		{"PaGeDoWn", "PaGeDoWn", twin.KeyPgDown, true},
+
+		// Invalid inputs
+		{"unknown-key", "unknown-key", 0, false},
+		{"alt-x", "alt-x", 0, false},
+		{"alt-", "alt-", 0, false},
+		{"ctrl-a", "ctrl-a", 0, false},
+		{"", "", 0, false},
+		{"space", "space", 0, false}, // space is a rune, not a keycode
+		{"a", "a", 0, false},         // single char is a rune
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, valid := parseKeyCodeName(tt.input)
+			if valid != tt.valid {
+				t.Errorf("parseKeyCodeName(%q) valid = %v, want %v", tt.input, valid, tt.valid)
+			}
+			if valid && got != tt.expected {
+				t.Errorf("parseKeyCodeName(%q) = %v, want %v", tt.input, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestParseRuneKeyName tests parsing of rune key names
+func TestParseRuneKeyName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected rune
+		valid    bool
+	}{
+		// Control characters
+		{"ctrl-a", "ctrl-a", 1, true},
+		{"ctrl-b", "ctrl-b", 2, true},
+		{"ctrl-c", "ctrl-c", 3, true},
+		{"ctrl-d", "ctrl-d", 4, true},
+		{"ctrl-n", "ctrl-n", 14, true},
+		{"ctrl-p", "ctrl-p", 16, true},
+		{"ctrl-t", "ctrl-t", 20, true},
+		{"ctrl-u", "ctrl-u", 21, true},
+		{"ctrl-z", "ctrl-z", 26, true},
+
+		// Special rune names
+		{"space", "space", ' ', true},
+		{"space-upper", "SPACE", ' ', true},
+		{"space-mixed", "Space", ' ', true},
+		{"tab", "tab", '\t', true},
+		{"tab-escape", "\\t", '\t', true},
+		{"newline", "\\n", '\n', true},
+
+		// Single characters
+		{"letter-a", "a", 'a', true},
+		{"letter-z", "z", 'z', true},
+		{"letter-A", "A", 'A', true},
+		{"letter-Z", "Z", 'Z', true},
+		{"digit-0", "0", '0', true},
+		{"digit-9", "9", '9', true},
+		{"slash", "/", '/', true},
+		{"question", "?", '?', true},
+		{"ampersand", "&", '&', true},
+		{"colon", ":", ':', true},
+		{"equals", "=", '=', true},
+		{"less-than", "<", '<', true},
+		{"greater-than", ">", '>', true},
+		{"single-quote", "'", '\'', true},
+
+		// Invalid inputs
+		{"CTRL-A", "CTRL-A", 0, false}, // uppercase not supported
+		{"Ctrl-A", "Ctrl-A", 0, false}, // mixed case not supported
+		{"ctrl-A", "ctrl-A", 0, false}, // uppercase letter not supported
+		{"ctrl-invalid", "^1", 0, false},
+		{"ctrl-invalid-2", "^@", 0, false},
+		{"multi-char", "ab", 0, false},
+		{"empty", "", 0, false},
+		{"escape", "escape", 0, false}, // escape is a keycode
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, valid := parseRuneKeyName(tt.input)
+			if valid != tt.valid {
+				t.Errorf("parseRuneKeyName(%q) valid = %v, want %v", tt.input, valid, tt.valid)
+			}
+			if valid && got != tt.expected {
+				t.Errorf("parseRuneKeyName(%q) = %d (%c), want %d (%c)", tt.input, got, got, tt.expected, tt.expected)
+			}
+		})
+	}
+}
+
+// TestActionNameReverseMaps verifies that every action enum has a name entry and round-trips correctly
+func TestActionNameReverseMaps(t *testing.T) {
+	// Build reverse maps
+	reverseMapOnce.Do(buildReverseMaps)
+
+	t.Run("ViewingActions", func(t *testing.T) {
+		// Check all viewing actions have names
+		for action := NoAction; action <= ScrollHome; action++ {
+			name, ok := actionNames[action]
+			if !ok {
+				t.Errorf("Action %d has no name", action)
+				continue
+			}
+
+			// Check reverse lookup
+			reversedAction, ok := actionNamesReverse[name]
+			if !ok {
+				t.Errorf("Action name %q not in reverse map", name)
+				continue
+			}
+
+			if reversedAction != action {
+				t.Errorf("Action %d -> %q -> %d (mismatch)", action, name, reversedAction)
+			}
+		}
+
+		// Check no duplicate names
+		seen := make(map[string]Action)
+		for action, name := range actionNames {
+			if prev, exists := seen[name]; exists {
+				t.Errorf("Duplicate name %q for actions %d and %d", name, prev, action)
+			}
+			seen[name] = action
+		}
+	})
+
+	t.Run("SearchActions", func(t *testing.T) {
+		for action := NoAction; action <= HistoryNext; action++ {
+			name, ok := actionNames[action]
+			if !ok {
+				t.Errorf("Action %d has no name", action)
+				continue
+			}
+
+			reversedAction, ok := actionNamesReverse[name]
+			if !ok {
+				t.Errorf("Action name %q not in reverse map", name)
+				continue
+			}
+
+			if reversedAction != action {
+				t.Errorf("Action %d -> %q -> %d (mismatch)", action, name, reversedAction)
+			}
+		}
+	})
+
+	t.Run("FilterActions", func(t *testing.T) {
+		for action := NoAction; action <= ScrollPageDown; action++ {
+			name, ok := actionNames[action]
+			if !ok {
+				t.Errorf("Action %d has no name", action)
+				continue
+			}
+
+			reversedAction, ok := actionNamesReverse[name]
+			if !ok {
+				t.Errorf("Action name %q not in reverse map", name)
+				continue
+			}
+
+			if reversedAction != action {
+				t.Errorf("Action %d -> %q -> %d (mismatch)", action, name, reversedAction)
+			}
+		}
+	})
+
+	t.Run("GotoLineActions", func(t *testing.T) {
+		for action := NoAction; action <= Quit; action++ {
+			name, ok := actionNames[action]
+			if !ok {
+				t.Errorf("Action %d has no name", action)
+				continue
+			}
+
+			reversedAction, ok := actionNamesReverse[name]
+			if !ok {
+				t.Errorf("Action name %q not in reverse map", name)
+				continue
+			}
+
+			if reversedAction != action {
+				t.Errorf("Action %d -> %q -> %d (mismatch)", action, name, reversedAction)
+			}
+		}
+	})
+
+	t.Run("ColonCommandActions", func(t *testing.T) {
+		for action := NoAction; action <= Quit; action++ {
+			name, ok := actionNames[action]
+			if !ok {
+				t.Errorf("Action %d has no name", action)
+				continue
+			}
+
+			reversedAction, ok := actionNamesReverse[name]
+			if !ok {
+				t.Errorf("Action name %q not in reverse map", name)
+				continue
+			}
+
+			if reversedAction != action {
+				t.Errorf("Action %d -> %q -> %d (mismatch)", action, name, reversedAction)
+			}
+		}
+	})
+}
+
+// TestBuildKeyBindings verifies that building key bindings from default slices doesn't panic
+func TestBuildKeyBindings(t *testing.T) {
+	t.Run("ViewingBindings", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("buildKeyBindings panicked: %v", r)
+			}
+		}()
+		kb := buildKeyBindings(defaultViewingEntries)
+		if kb.KeyCodeBindings == nil {
+			t.Error("KeyCodeBindings is nil")
+		}
+		if kb.RuneBindings == nil {
+			t.Error("RuneBindings is nil")
+		}
+		if len(kb.KeyCodeBindings) == 0 && len(kb.RuneBindings) == 0 {
+			t.Error("No bindings were created")
+		}
+	})
+
+	t.Run("SearchBindings", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("buildKeyBindings panicked: %v", r)
+			}
+		}()
+		kb := buildKeyBindings(defaultSearchEntries)
+		if kb.KeyCodeBindings == nil || kb.RuneBindings == nil {
+			t.Error("Bindings maps are nil")
+		}
+	})
+
+	t.Run("FilterBindings", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("buildKeyBindings panicked: %v", r)
+			}
+		}()
+		kb := buildKeyBindings(defaultFilterEntries)
+		if kb.KeyCodeBindings == nil || kb.RuneBindings == nil {
+			t.Error("Bindings maps are nil")
+		}
+	})
+
+	t.Run("GotoLineBindings", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("buildKeyBindings panicked: %v", r)
+			}
+		}()
+		kb := buildKeyBindings(defaultGotoLineEntries)
+		if kb.KeyCodeBindings == nil || kb.RuneBindings == nil {
+			t.Error("Bindings maps are nil")
+		}
+	})
+
+	t.Run("ColonCommandBindings", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("buildKeyBindings panicked: %v", r)
+			}
+		}()
+		kb := buildKeyBindings(defaultColonCommandEntries)
+		if kb.KeyCodeBindings == nil || kb.RuneBindings == nil {
+			t.Error("Bindings maps are nil")
+		}
+	})
+}
+
+// TestDefaultKeybindingsTextRoundTrip verifies that the default keybindings text can be parsed back
+func TestDefaultKeybindingsTextRoundTrip(t *testing.T) {
+	text := DefaultKeybindingsText()
+	if text == "" {
+		t.Fatal("DefaultKeybindingsText returned empty string")
+	}
+
+	// Verify all expected sections are present
+	expectedSections := []string{"[viewing]", "[search]", "[filter]", "[goto-line]", "[colon-command]", "[input]"}
+	for _, section := range expectedSections {
+		if !strings.Contains(text, section) {
+			t.Errorf("DefaultKeybindingsText missing section %s", section)
+		}
+	}
+
+	// Write to a temp file and parse it back
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "keybindings")
+
+	err := os.WriteFile(tmpFile, []byte(text), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	bindings, warnings, err := ParseKeybindingsFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Failed to parse default keybindings text: %v", err)
+	}
+
+	if len(warnings) > 0 {
+		t.Errorf("Got %d warnings parsing default keybindings text:", len(warnings))
+		for _, w := range warnings {
+			t.Errorf("  %v", w)
+		}
+	}
+
+	// Verify key bindings are present
+	if _, ok := bindings.Viewing.RuneBindings['q']; !ok {
+		t.Error("'q' binding missing from viewing mode")
+	}
+	if _, ok := bindings.Viewing.KeyCodeBindings[twin.KeyEscape]; !ok {
+		t.Error("'escape' binding missing from viewing mode")
+	}
+}
+
+// TestParserCommentsAndBlankLines verifies that comments and blank lines are ignored
+func TestParserCommentsAndBlankLines(t *testing.T) {
+	input := `
+# This is a comment
+[viewing]
+# Another comment
+q  quit
+
+  # Indented comment
+r  reload
+# Comment at end
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "keybindings")
+	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	bindings, warnings, err := ParseKeybindingsFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(warnings) > 0 {
+		t.Errorf("Got unexpected warnings: %v", warnings)
+	}
+
+	if action, ok := bindings.Viewing.RuneBindings['q']; !ok || action != Quit {
+		t.Error("'q' binding not parsed correctly")
+	}
+
+	if action, ok := bindings.Viewing.RuneBindings['r']; !ok || action != Reload {
+		t.Error("'r' binding not parsed correctly")
+	}
+}
+
+// TestParserUnknownSection verifies that unknown sections generate warnings
+func TestParserUnknownSection(t *testing.T) {
+	input := `
+[unknown-section]
+a  some-action
+
+[viewing]
+q  quit
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "keybindings")
+	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	bindings, warnings, err := ParseKeybindingsFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(warnings) == 0 {
+		t.Error("Expected warning for unknown section")
+	}
+
+	foundUnknownSectionWarning := false
+	for _, w := range warnings {
+		if strings.Contains(w.Error(), "unknown section") {
+			foundUnknownSectionWarning = true
+			break
+		}
+	}
+
+	if !foundUnknownSectionWarning {
+		t.Errorf("Expected 'unknown section' warning, got: %v", warnings)
+	}
+
+	// The valid [viewing] section must still have been parsed
+	if action, ok := bindings.Viewing.RuneBindings['q']; !ok || action != Quit {
+		t.Error("Valid viewing section was not parsed correctly")
+	}
+}
+
+// TestParserBadFieldCount verifies that lines with wrong field count generate warnings
+func TestParserBadFieldCount(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"one-field", "[viewing]\nq\n"},
+		{"three-fields", "[viewing]\nq quit extra\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			tmpFile := filepath.Join(tmpDir, "keybindings")
+			err := os.WriteFile(tmpFile, []byte(tt.input), 0644)
+			if err != nil {
+				t.Fatalf("Failed to write temp file: %v", err)
+			}
+
+			_, warnings, err := ParseKeybindingsFile(tmpFile)
+			if err != nil {
+				t.Fatalf("Parse failed: %v", err)
+			}
+
+			if len(warnings) == 0 {
+				t.Error("Expected warning for bad field count")
+			}
+
+			foundFieldCountWarning := false
+			for _, w := range warnings {
+				if strings.Contains(w.Error(), "expected 2 fields") {
+					foundFieldCountWarning = true
+					break
+				}
+			}
+
+			if !foundFieldCountWarning {
+				t.Errorf("Expected 'expected 2 fields' warning, got: %v", warnings)
+			}
+		})
+	}
+}
+
+// TestParserUnknownKey verifies that unknown keys generate warnings
+func TestParserUnknownKey(t *testing.T) {
+	input := `
+[viewing]
+unknown-key  quit
+ctrl-1  quit
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "keybindings")
+	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	_, warnings, err := ParseKeybindingsFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(warnings) < 2 {
+		t.Errorf("Expected at least 2 warnings for unknown keys, got %d", len(warnings))
+	}
+
+	unknownKeyCount := 0
+	for _, w := range warnings {
+		if strings.Contains(w.Error(), "unknown key name") {
+			unknownKeyCount++
+		}
+	}
+
+	if unknownKeyCount < 2 {
+		t.Errorf("Expected 2 'unknown key name' warnings, got %d", unknownKeyCount)
+	}
+}
+
+// TestParserUnknownAction verifies that unknown actions generate warnings
+func TestParserUnknownAction(t *testing.T) {
+	input := `
+[viewing]
+q  unknown-action
+r  another-bad-action
+
+[search]
+enter  bad-search-action
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "keybindings")
+	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	_, warnings, err := ParseKeybindingsFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(warnings) < 3 {
+		t.Errorf("Expected at least 3 warnings for unknown actions, got %d", len(warnings))
+	}
+
+	unknownActionCount := 0
+	for _, w := range warnings {
+		if strings.Contains(w.Error(), "unknown action") {
+			unknownActionCount++
+		}
+	}
+
+	if unknownActionCount < 3 {
+		t.Errorf("Expected 3 'unknown action' warnings, got %d", unknownActionCount)
+	}
+}
+
+// TestParserNoAction verifies that 'noaction' maps to zero values
+func TestParserNoAction(t *testing.T) {
+	input := `
+[viewing]
+q  noaction
+
+[search]
+enter  noaction
+
+[filter]
+escape  noaction
+
+[goto-line]
+g  noaction
+
+[colon-command]
+n  noaction
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "keybindings")
+	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	bindings, warnings, err := ParseKeybindingsFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(warnings) > 0 {
+		t.Errorf("Got unexpected warnings: %v", warnings)
+	}
+
+	if action, ok := bindings.Viewing.RuneBindings['q']; !ok || action != NoAction {
+		t.Errorf("'q' should map to NoAction (0), got %d", action)
+	}
+
+	if action, ok := bindings.Search.KeyCodeBindings[twin.KeyEnter]; !ok || action != NoAction {
+		t.Errorf("'enter' should map to NoAction (0), got %d", action)
+	}
+
+	if action, ok := bindings.Filter.KeyCodeBindings[twin.KeyEscape]; !ok || action != NoAction {
+		t.Errorf("'escape' should map to NoAction (0), got %d", action)
+	}
+
+	if action, ok := bindings.GotoLine.RuneBindings['g']; !ok || action != NoAction {
+		t.Errorf("'g' should map to NoAction (0), got %d", action)
+	}
+
+	if action, ok := bindings.ColonCommand.RuneBindings['n']; !ok || action != NoAction {
+		t.Errorf("'n' should map to NoAction (0), got %d", action)
+	}
+}
+
+// TestParserVariousKeyFormats verifies various key formats work correctly
+func TestParserVariousKeyFormats(t *testing.T) {
+	input := `
+[viewing]
+# Special keys
+escape  quit
+enter  scroll-down
+pageup  scroll-page-up
+pagedown  scroll-page-down
+up  scroll-up
+down  scroll-down
+
+# Alt keys
+alt-up  scroll-up
+alt-down  scroll-down
+alt-left  scroll-left
+alt-right  scroll-right
+
+# Control characters
+ctrl-a  scroll-home
+ctrl-d  scroll-half-page-down
+ctrl-u  scroll-half-page-up
+
+# Single characters
+q  quit
+/  search-forward
+?  search-backward
+space  scroll-page-down
+
+# Case-sensitive single chars
+G  scroll-bottom
+N  previous-search-hit
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "keybindings")
+	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	bindings, warnings, err := ParseKeybindingsFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(warnings) > 0 {
+		t.Errorf("Got unexpected warnings: %v", warnings)
+	}
+
+	kb := bindings.Viewing
+
+	// Check special keys
+	tests := []struct {
+		keyCode twin.KeyCode
+		action  Action
+	}{
+		{twin.KeyEscape, Quit},
+		{twin.KeyEnter, ScrollDown},
+		{twin.KeyPgUp, ScrollPageUp},
+		{twin.KeyPgDown, ScrollPageDown},
+		{twin.KeyUp, ScrollUp},
+		{twin.KeyDown, ScrollDown},
+		{twin.KeyAltUp, ScrollUp},
+		{twin.KeyAltDown, ScrollDown},
+		{twin.KeyAltLeft, ScrollLeft},
+		{twin.KeyAltRight, ScrollRight},
+	}
+
+	for _, tt := range tests {
+		if action, ok := kb.KeyCodeBindings[tt.keyCode]; !ok || action != tt.action {
+			t.Errorf("KeyCode %d should map to action %d, got %d (ok=%v)", tt.keyCode, tt.action, action, ok)
+		}
+	}
+
+	// Check rune bindings
+	runeTests := []struct {
+		r      rune
+		action Action
+	}{
+		{1, ScrollHome},         // ^A
+		{4, ScrollHalfPageDown}, // ^D
+		{21, ScrollHalfPageUp},  // ^U
+		{'q', Quit},
+		{'/', SearchForward},
+		{'?', SearchBackward},
+		{' ', ScrollPageDown},
+		{'G', ScrollBottom},
+		{'N', PreviousSearchHit},
+	}
+
+	for _, tt := range runeTests {
+		if action, ok := kb.RuneBindings[tt.r]; !ok || action != tt.action {
+			t.Errorf("Rune %d (%c) should map to action %d, got %d (ok=%v)", tt.r, tt.r, tt.action, action, ok)
+		}
+	}
+}
+
+// TestParserPerKeyMerge verifies that the parser overlays user-specified keys
+// on top of defaults: overridden keys change, everything else is preserved.
+func TestParserPerKeyMerge(t *testing.T) {
+	input := `
+[viewing]
+escape  help
+q  reload
+x  quit
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "keybindings")
+	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	bindings, warnings, err := ParseKeybindingsFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(warnings) > 0 {
+		t.Errorf("Got unexpected warnings: %v", warnings)
+	}
+
+	// Overridden / new keys
+	if action, ok := bindings.Viewing.KeyCodeBindings[twin.KeyEscape]; !ok || action != Help {
+		t.Errorf("Viewing escape should be Help, got %d", action)
+	}
+	if action, ok := bindings.Viewing.RuneBindings['q']; !ok || action != Reload {
+		t.Errorf("Viewing 'q' should be Reload, got %d", action)
+	}
+	if action, ok := bindings.Viewing.RuneBindings['x']; !ok || action != Quit {
+		t.Errorf("Viewing 'x' should be Quit, got %d", action)
+	}
+
+	// All unmentioned viewing defaults must be intact.
+	defaults := DefaultModeBindings()
+	for k, defaultAction := range defaults.Viewing.RuneBindings {
+		if k == 'q' || k == 'x' {
+			continue
+		}
+		if got, ok := bindings.Viewing.RuneBindings[k]; !ok || got != defaultAction {
+			t.Errorf("Viewing rune %c: expected default %d, got %d (ok=%v)", k, defaultAction, got, ok)
+		}
+	}
+	for k, defaultAction := range defaults.Viewing.KeyCodeBindings {
+		if k == twin.KeyEscape {
+			continue
+		}
+		if got, ok := bindings.Viewing.KeyCodeBindings[k]; !ok || got != defaultAction {
+			t.Errorf("Viewing keycode %d: expected default %d, got %d (ok=%v)", k, defaultAction, got, ok)
+		}
+	}
+
+	// Untouched sections must equal their defaults.
+	if action, ok := bindings.Search.KeyCodeBindings[twin.KeyEnter]; !ok || action != defaults.Search.KeyCodeBindings[twin.KeyEnter] {
+		t.Error("Search Enter binding doesn't match default")
+	}
+	if action, ok := bindings.GotoLine.RuneBindings['g']; !ok || action != defaults.GotoLine.RuneBindings['g'] {
+		t.Error("GotoLine 'g' binding doesn't match default")
+	}
+}
+
+// TestParserClear verifies that !clear resets all defaults; only user-specified
+// keys survive, and sections not mentioned at all end up empty.
+func TestParserClear(t *testing.T) {
+	input := `
+!clear
+
+[viewing]
+x  quit
+
+[search]
+enter  accept
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "keybindings")
+	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	bindings, warnings, err := ParseKeybindingsFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(warnings) > 0 {
+		t.Errorf("Got unexpected warnings: %v", warnings)
+	}
+
+	// Explicitly listed keys must be present.
+	if action, ok := bindings.Viewing.RuneBindings['x']; !ok || action != Quit {
+		t.Error("Viewing 'x' should be Quit")
+	}
+	if action, ok := bindings.Search.KeyCodeBindings[twin.KeyEnter]; !ok || action != Accept {
+		t.Error("Search Enter should be Accept")
+	}
+
+	// All defaults must be gone from viewing.
+	defaults := DefaultModeBindings()
+	for k := range defaults.Viewing.RuneBindings {
+		if _, ok := bindings.Viewing.RuneBindings[k]; ok {
+			t.Errorf("Viewing default rune %c survived !clear", k)
+		}
+	}
+	for k := range defaults.Viewing.KeyCodeBindings {
+		if _, ok := bindings.Viewing.KeyCodeBindings[k]; ok {
+			t.Errorf("Viewing default keycode %d survived !clear", k)
+		}
+	}
+
+	// Unmentioned defaults must be gone from search too.
+	for k := range defaults.Search.KeyCodeBindings {
+		if k == twin.KeyEnter {
+			continue // user listed this
+		}
+		if _, ok := bindings.Search.KeyCodeBindings[k]; ok {
+			t.Errorf("Search default keycode %d survived !clear", k)
+		}
+	}
+
+	// GotoLine was not mentioned at all — must be completely empty.
+	if len(bindings.GotoLine.KeyCodeBindings) != 0 || len(bindings.GotoLine.RuneBindings) != 0 {
+		t.Error("GotoLine should be empty when !clear is set and section is not mentioned")
+	}
+}
+
+// TestNoActionUnbindsKey verifies that 'noaction' unbinds a specific key
+// without disturbing any other defaults.
+func TestNoActionUnbindsKey(t *testing.T) {
+	input := `
+[viewing]
+q  noaction
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "keybindings")
+	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	bindings, warnings, err := ParseKeybindingsFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(warnings) > 0 {
+		t.Errorf("Got unexpected warnings: %v", warnings)
+	}
+
+	// 'q' must be unbound.
+	if action, ok := bindings.Viewing.RuneBindings['q']; !ok || action != NoAction {
+		t.Errorf("Expected 'q' -> NoAction, got action=%d ok=%v", action, ok)
+	}
+
+	// All other viewing defaults must be intact.
+	defaults := DefaultModeBindings()
+	for k, defaultAction := range defaults.Viewing.RuneBindings {
+		if k == 'q' {
+			continue
+		}
+		if got, ok := bindings.Viewing.RuneBindings[k]; !ok || got != defaultAction {
+			t.Errorf("Viewing rune %c: expected default %d, got %d (ok=%v)", k, defaultAction, got, ok)
+		}
+	}
+}
+
+// TestParserBindingOutsideSection verifies warning for bindings outside a section
+func TestParserBindingOutsideSection(t *testing.T) {
+	input := `
+# Comment
+q  quit
+
+[viewing]
+r  reload
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "keybindings")
+	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	_, warnings, err := ParseKeybindingsFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(warnings) == 0 {
+		t.Error("Expected warning for binding outside section")
+	}
+
+	foundWarning := false
+	for _, w := range warnings {
+		if strings.Contains(w.Error(), "binding outside of section") {
+			foundWarning = true
+			break
+		}
+	}
+
+	if !foundWarning {
+		t.Errorf("Expected 'binding outside of section' warning, got: %v", warnings)
+	}
+}
+
+// TestDefaultModeBindingsIdempotent verifies DefaultModeBindings returns equivalent data on every call
+func TestDefaultModeBindingsIdempotent(t *testing.T) {
+	first := DefaultModeBindings()
+	second := DefaultModeBindings()
+
+	// Each call returns independent copies (maps are cloned), but the data must be identical.
+	if len(first.Viewing.KeyCodeBindings) != len(second.Viewing.KeyCodeBindings) {
+		t.Error("Viewing KeyCodeBindings have different lengths")
+	}
+
+	// Verify some specific bindings match
+	if first.Viewing.RuneBindings['q'] != second.Viewing.RuneBindings['q'] {
+		t.Error("Viewing RuneBindings for 'q' don't match")
+	}
+
+	if first.Search.KeyCodeBindings[twin.KeyEnter] != second.Search.KeyCodeBindings[twin.KeyEnter] {
+		t.Error("Search KeyCodeBindings for Enter don't match")
+	}
+}
+
+// TestDefaultModeBindingsMutationIsolation verifies that mutating a returned
+// ModeBindings does not corrupt the shared cache or subsequent calls.
+func TestDefaultModeBindingsMutationIsolation(t *testing.T) {
+	first := DefaultModeBindings()
+
+	// Remember the original action for 'q' in Viewing mode.
+	originalAction := first.Viewing.RuneBindings['q']
+
+	// Mutate the returned copy in place.
+	first.Viewing.RuneBindings['q'] = NoAction
+
+	// A fresh call must return the unmodified (cached) data.
+	second := DefaultModeBindings()
+	if second.Viewing.RuneBindings['q'] != originalAction {
+		t.Errorf("cache was corrupted: expected 'q' -> %v, got %v", originalAction, second.Viewing.RuneBindings['q'])
+	}
+}
+
+// TestParserMultipleSectionsSameMode verifies that later bindings override earlier ones
+func TestParserMultipleSectionsSameMode(t *testing.T) {
+	input := `
+[viewing]
+q  quit
+
+[viewing]
+q  reload
+r  quit
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "keybindings")
+	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	bindings, warnings, err := ParseKeybindingsFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(warnings) > 0 {
+		t.Errorf("Got unexpected warnings: %v", warnings)
+	}
+
+	// Later binding should override
+	if action, ok := bindings.Viewing.RuneBindings['q']; !ok || action != Reload {
+		t.Errorf("'q' should be Reload (overridden), got %d", action)
+	}
+
+	if action, ok := bindings.Viewing.RuneBindings['r']; !ok || action != Quit {
+		t.Error("'r' binding from second section not found")
+	}
+}
+
+// TestInputActionRoundTrip tests that input action names round-trip correctly
+func TestInputActionRoundTrip(t *testing.T) {
+	// Ensure reverse maps are built
+	reverseMapOnce.Do(buildReverseMaps)
+
+	// Check all input actions have names
+	expectedActions := []InputAction{
+		NoInputAction,
+		CursorLeft,
+		CursorRight,
+		CursorHome,
+		CursorEnd,
+		Backspace,
+		Delete,
+		DeleteToEnd,
+		DeleteToStart,
+	}
+
+	for _, action := range expectedActions {
+		name, ok := inputActionNames[action]
+		if !ok {
+			t.Errorf("InputAction %d missing name in inputActionNames", action)
+			continue
+		}
+
+		reversedAction, ok := inputActionNamesReverse[name]
+		if !ok {
+			t.Errorf("InputAction name %q missing in inputActionNamesReverse", name)
+			continue
+		}
+
+		if reversedAction != action {
+			t.Errorf("InputAction %d -> name %q -> action %d (mismatch)", action, name, reversedAction)
+		}
+	}
+}
+
+// TestInputBindingsParser tests parsing of [input] section
+func TestInputBindingsParser(t *testing.T) {
+	input := `
+[input]
+left          cursor-left
+right         cursor-right
+home          cursor-home
+end           cursor-end
+backspace     backspace
+delete        delete
+ctrl-a        cursor-home
+ctrl-e        cursor-end
+ctrl-b        cursor-left
+ctrl-f        cursor-right
+ctrl-k        delete-to-end
+ctrl-u        delete-to-start
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "keybindings")
+	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	bindings, warnings, err := ParseKeybindingsFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(warnings) > 0 {
+		t.Errorf("Got unexpected warnings: %v", warnings)
+	}
+
+	// Verify key code bindings
+	keycodeTests := []struct {
+		key    twin.KeyCode
+		action InputAction
+	}{
+		{twin.KeyLeft, CursorLeft},
+		{twin.KeyRight, CursorRight},
+		{twin.KeyHome, CursorHome},
+		{twin.KeyEnd, CursorEnd},
+		{twin.KeyBackspace, Backspace},
+		{twin.KeyDelete, Delete},
+	}
+
+	for _, tt := range keycodeTests {
+		if action, ok := bindings.Input.KeyCodeBindings[tt.key]; !ok || action != tt.action {
+			t.Errorf("Expected key %v to map to action %v, got %v (found: %v)", tt.key, tt.action, action, ok)
+		}
+	}
+
+	// Verify rune bindings
+	runeTests := []struct {
+		r      rune
+		action InputAction
+	}{
+		{'\x01', CursorHome},    // ctrl-a
+		{'\x05', CursorEnd},     // ctrl-e
+		{'\x02', CursorLeft},    // ctrl-b
+		{'\x06', CursorRight},   // ctrl-f
+		{'\x0b', DeleteToEnd},   // ctrl-k
+		{'\x15', DeleteToStart}, // ctrl-u
+	}
+
+	for _, tt := range runeTests {
+		if action, ok := bindings.Input.RuneBindings[tt.r]; !ok || action != tt.action {
+			t.Errorf("Expected rune %q (%#x) to map to action %v, got %v (found: %v)", tt.r, tt.r, tt.action, action, ok)
+		}
+	}
+}
+
+// TestParserInputPerKeyMerge tests that user-specified input bindings overlay
+// defaults per-key, leaving all other input defaults intact.
+func TestParserInputPerKeyMerge(t *testing.T) {
+	input := `
+[input]
+left   cursor-right
+right  cursor-left
+ctrl-a cursor-end
+ctrl-e cursor-home
+`
+
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "keybindings")
+	err := os.WriteFile(tmpFile, []byte(input), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	bindings, warnings, err := ParseKeybindingsFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+	if len(warnings) > 0 {
+		t.Errorf("Got unexpected warnings: %v", warnings)
+	}
+
+	// Overridden bindings
+	if action, ok := bindings.Input.KeyCodeBindings[twin.KeyLeft]; !ok || action != CursorRight {
+		t.Errorf("Expected left to map to CursorRight, got %v", action)
+	}
+	if action, ok := bindings.Input.KeyCodeBindings[twin.KeyRight]; !ok || action != CursorLeft {
+		t.Errorf("Expected right to map to CursorLeft, got %v", action)
+	}
+	if action, ok := bindings.Input.RuneBindings['\x01']; !ok || action != CursorEnd {
+		t.Errorf("Expected ctrl-a to map to CursorEnd, got %v", action)
+	}
+	if action, ok := bindings.Input.RuneBindings['\x05']; !ok || action != CursorHome {
+		t.Errorf("Expected ctrl-e to map to CursorHome, got %v", action)
+	}
+
+	// Unmentioned input defaults must be intact.
+	defaults := DefaultModeBindings()
+	if action, ok := bindings.Input.KeyCodeBindings[twin.KeyHome]; !ok || action != defaults.Input.KeyCodeBindings[twin.KeyHome] {
+		t.Error("Input Home binding lost")
+	}
+	if action, ok := bindings.Input.RuneBindings['\x0b']; !ok || action != defaults.Input.RuneBindings['\x0b'] {
+		t.Error("Input ctrl-k binding lost")
+	}
+}
+
+// TestDefaultKeybindingsTextIncludesInput tests that default text includes [input] section
+func TestDefaultKeybindingsTextIncludesInput(t *testing.T) {
+	text := DefaultKeybindingsText()
+
+	if !strings.Contains(text, "[input]") {
+		t.Error("DefaultKeybindingsText missing [input] section")
+	}
+
+	// Verify some expected bindings are present
+	expectedBindings := []string{
+		"left",
+		"cursor-left",
+		"ctrl-a",
+		"cursor-home",
+		"delete-to-end",
+	}
+
+	for _, expected := range expectedBindings {
+		if !strings.Contains(text, expected) {
+			t.Errorf("DefaultKeybindingsText missing expected text %q", expected)
+		}
+	}
+}
+
+// TestInputBindingsRoundTrip tests that input bindings round-trip through serialization
+func TestInputBindingsRoundTrip(t *testing.T) {
+	text := DefaultKeybindingsText()
+
+	// Write and re-parse
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "keybindings")
+	err := os.WriteFile(tmpFile, []byte(text), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write temp file: %v", err)
+	}
+
+	bindings, warnings, err := ParseKeybindingsFile(tmpFile)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if len(warnings) > 0 {
+		t.Errorf("Got warnings parsing default keybindings: %v", warnings)
+	}
+
+	// Verify default input bindings are present
+	defaults := DefaultModeBindings()
+
+	if len(bindings.Input.KeyCodeBindings) == 0 {
+		t.Error("Input KeyCodeBindings is empty after round-trip")
+	}
+
+	if len(bindings.Input.RuneBindings) == 0 {
+		t.Error("Input RuneBindings is empty after round-trip")
+	}
+
+	// Spot check a few bindings
+	if action, ok := bindings.Input.KeyCodeBindings[twin.KeyLeft]; !ok {
+		t.Error("KeyLeft binding missing after round-trip")
+	} else if expected := defaults.Input.KeyCodeBindings[twin.KeyLeft]; action != expected {
+		t.Errorf("KeyLeft action mismatch: got %v, want %v", action, expected)
+	}
+
+	if action, ok := bindings.Input.RuneBindings['\x01']; !ok {
+		t.Error("Ctrl-A binding missing after round-trip")
+	} else if expected := defaults.Input.RuneBindings['\x01']; action != expected {
+		t.Errorf("Ctrl-A action mismatch: got %v, want %v", action, expected)
+	}
+}
+
+func TestKeyForAction(t *testing.T) {
+	defaults := DefaultModeBindings()
+
+	// Default colon-command bindings: n→NextFile, p→PreviousFile, x→FirstFile
+	if got := keyForAction(defaults.ColonCommand, NextFile); got != "n" {
+		t.Errorf("NextFile key: got %q, want %q", got, "n")
+	}
+	if got := keyForAction(defaults.ColonCommand, PreviousFile); got != "p" {
+		t.Errorf("PreviousFile key: got %q, want %q", got, "p")
+	}
+	if got := keyForAction(defaults.ColonCommand, FirstFile); got != "x" {
+		t.Errorf("FirstFile key: got %q, want %q", got, "x")
+	}
+
+	// Unbound action returns "?"
+	if got := keyForAction(defaults.ColonCommand, ScrollUp); got != "?" {
+		t.Errorf("Unbound action: got %q, want %q", got, "?")
+	}
+
+	// Custom rune binding overrides the default
+	custom := DefaultModeBindings()
+	custom.ColonCommand.RuneBindings['j'] = NextFile
+	delete(custom.ColonCommand.RuneBindings, 'n')
+	if got := keyForAction(custom.ColonCommand, NextFile); got != "j" {
+		t.Errorf("Custom rune binding: got %q, want %q", got, "j")
+	}
+
+	// KeyCode binding is found when no rune binding exists
+	keyCodeOnly := DefaultModeBindings()
+	delete(keyCodeOnly.ColonCommand.RuneBindings, 'n')
+	keyCodeOnly.ColonCommand.KeyCodeBindings[twin.KeyEnter] = NextFile
+	if got := keyForAction(keyCodeOnly.ColonCommand, NextFile); got != "enter" {
+		t.Errorf("KeyCode binding: got %q, want %q", got, "enter")
+	}
+}
+
+func TestRuneDisplayName(t *testing.T) {
+	tests := []struct {
+		r    rune
+		want string
+	}{
+		{'n', "n"},
+		{'N', "N"},
+		{' ', "space"},
+		{'\t', "tab"},
+		{1, "ctrl-a"},  // ctrl-a
+		{14, "ctrl-n"}, // ctrl-n
+		{26, "ctrl-z"}, // ctrl-z
+	}
+	for _, tt := range tests {
+		if got := runeDisplayName(tt.r); got != tt.want {
+			t.Errorf("runeDisplayName(%q): got %q, want %q", tt.r, got, tt.want)
+		}
+	}
+}
+
+func TestKeyCodeDisplayName(t *testing.T) {
+	// escape has one alias; verify a canonical name is returned.
+	if got := keyCodeDisplayName(twin.KeyEscape); got == "" {
+		t.Error("keyCodeDisplayName(KeyEscape) returned empty string")
+	}
+	// enter has one alias too.
+	if got := keyCodeDisplayName(twin.KeyEnter); got == "" {
+		t.Error("keyCodeDisplayName(KeyEnter) returned empty string")
+	}
+	// pageup / pgup: both map to KeyPgUp; the shorter "pgup" should win.
+	if got := keyCodeDisplayName(twin.KeyPgUp); got != "pgup" {
+		t.Errorf("keyCodeDisplayName(KeyPgUp): got %q, want %q", got, "pgup")
+	}
+	// pagedown / pgdown: both map to KeyPgDown; "pgdown" should win.
+	if got := keyCodeDisplayName(twin.KeyPgDown); got != "pgdown" {
+		t.Errorf("keyCodeDisplayName(KeyPgDown): got %q, want %q", got, "pgdown")
+	}
+}

--- a/internal/pager-search.go
+++ b/internal/pager-search.go
@@ -1,8 +1,6 @@
 package internal
 
 import (
-	"fmt"
-
 	"github.com/rivo/uniseg"
 	log "github.com/sirupsen/logrus"
 	"github.com/walles/moor/v2/internal/linemetadata"
@@ -59,7 +57,9 @@ func (p *Pager) scrollToSearchHits() {
 }
 
 // Scroll to the next search hit, when the user presses 'n'.
-func (p *Pager) scrollToNextSearchHit() {
+// wrapAround restarts the search from the top when true, or continues from the
+// current position when false.
+func (p *Pager) scrollToNextSearchHit(wrapAround bool) {
 	if p.search.Inactive() {
 		// Nothing to search for, never mind
 		return
@@ -75,25 +75,21 @@ func (p *Pager) scrollToNextSearchHit() {
 		return
 	}
 
-	if p.isViewing() && p.isScrolledToEnd() {
+	if !wrapAround && p.isScrolledToEnd() {
 		p.mode = PagerModeNotFound{pager: p}
 		return
 	}
 
 	var firstSearchIndex linemetadata.Index
-
-	switch {
-	case p.isViewing():
-		// Start searching on the first line below the bottom of the screen
-		firstSearchIndex = *p.getLastVisibleLineIndex()
-
-	case p.isNotFound():
-		// Restart searching from the top
+	if wrapAround {
+		// Restart searching from the top; establishing viewing mode here ensures
+		// the mode is correct whether we arrive via executeAction (which already
+		// switched) or via a direct call (e.g. from tests).
 		p.mode = PagerModeViewing{pager: p}
 		firstSearchIndex = linemetadata.Index{}
-
-	default:
-		panic(fmt.Sprint("Unknown search mode when finding next: ", p.mode))
+	} else {
+		// Start searching on the first line below the bottom of the screen
+		firstSearchIndex = *p.getLastVisibleLineIndex()
 	}
 
 	firstHitIndex := FindFirstHit(p.Reader(), p.search, firstSearchIndex, nil, SearchDirectionForward)
@@ -174,7 +170,9 @@ func (p *Pager) scrollToSearchHitsBackwards() {
 }
 
 // Scroll backwards to the previous search hit, when the user presses 'N'.
-func (p *Pager) scrollToPreviousSearchHit() {
+// wrapAround restarts the search from the bottom when true, or continues from
+// the current position when false.
+func (p *Pager) scrollToPreviousSearchHit(wrapAround bool) {
 	if p.search.Inactive() {
 		// Nothing to search for, never mind
 		return
@@ -191,9 +189,11 @@ func (p *Pager) scrollToPreviousSearchHit() {
 	}
 
 	var firstSearchIndex linemetadata.Index
-
-	switch {
-	case p.isViewing():
+	if wrapAround {
+		// Restart searching from the bottom; same reasoning as scrollToNextSearchHit.
+		p.mode = PagerModeViewing{pager: p}
+		firstSearchIndex = *linemetadata.IndexFromLength(p.Reader().GetLineCount())
+	} else {
 		if p.scrollPosition.lineIndex(p).Index() == 0 {
 			// Already at the top, can't go further up
 			p.mode = PagerModeNotFound{pager: p}
@@ -203,14 +203,6 @@ func (p *Pager) scrollToPreviousSearchHit() {
 		// Start searching on the first line above the top of the screen
 		position := p.scrollPosition.PreviousLine(1)
 		firstSearchIndex = *position.lineIndex(p)
-
-	case p.isNotFound():
-		// Restart searching from the bottom
-		p.mode = PagerModeViewing{pager: p}
-		firstSearchIndex = *linemetadata.IndexFromLength(p.Reader().GetLineCount())
-
-	default:
-		panic(fmt.Sprint("Unknown search mode when finding previous: ", p.mode))
 	}
 
 	hitIndex := FindFirstHit(p.Reader(), p.search, firstSearchIndex, nil, SearchDirectionBackward)
@@ -529,9 +521,4 @@ func (p *Pager) scrollLeftToSearchHits() bool {
 func (p *Pager) isViewing() bool {
 	_, isViewing := p.mode.(PagerModeViewing)
 	return isViewing
-}
-
-func (p *Pager) isNotFound() bool {
-	_, isNotFound := p.mode.(PagerModeNotFound)
-	return isNotFound
 }

--- a/internal/pager-search_test.go
+++ b/internal/pager-search_test.go
@@ -116,7 +116,7 @@ func TestScrollToNextSearchHit_StartAtBottom(t *testing.T) {
 	pager.search.For("xxx")
 
 	// Scroll to the next search hit
-	pager.scrollToNextSearchHit()
+	pager.scrollToNextSearchHit(false)
 
 	assert.Equal(t, "NotFound", modeName(pager))
 }
@@ -129,7 +129,7 @@ func TestScrollToNextSearchHit_StartAtTop(t *testing.T) {
 	pager.search.For("xxx")
 
 	// Scroll to the next search hit
-	pager.scrollToNextSearchHit()
+	pager.scrollToNextSearchHit(false)
 
 	assert.Equal(t, "NotFound", modeName(pager))
 }
@@ -143,12 +143,12 @@ func TestScrollToNextSearchHit_WrapAfterNotFound(t *testing.T) {
 	pager.search.For("a")
 
 	// Scroll to the next search hit, this should take us into _NotFound
-	pager.scrollToNextSearchHit()
+	pager.scrollToNextSearchHit(false)
 	assert.Equal(t, "NotFound", modeName(pager))
 
 	// Scroll to the next search hit, this should wrap the search and take us to
 	// the top
-	pager.scrollToNextSearchHit()
+	pager.scrollToNextSearchHit(true)
 	assert.Equal(t, "Viewing", modeName(pager))
 	assert.Assert(t, pager.lineIndex().IsZero())
 }
@@ -162,12 +162,12 @@ func TestScrollToNextSearchHit_WrapAfterFound(t *testing.T) {
 	pager.search.For("f")
 
 	// Scroll to the next search hit, this should take us into _NotFound
-	pager.scrollToNextSearchHit()
+	pager.scrollToNextSearchHit(false)
 	assert.Equal(t, "NotFound", modeName(pager))
 
 	// Scroll to the next search hit, this should wrap the search and take us
 	// back to the bottom again
-	pager.scrollToNextSearchHit()
+	pager.scrollToNextSearchHit(true)
 	assert.Equal(t, "Viewing", modeName(pager))
 	assert.Equal(t, 4, pager.lineIndex().Index())
 }

--- a/internal/pager.go
+++ b/internal/pager.go
@@ -135,6 +135,9 @@ type Pager struct {
 	//
 	// Ref: https://github.com/walles/moor/issues/175
 	bookmarks map[rune]scrollPosition
+
+	// Key bindings for all modes
+	ModeBindings ModeBindings
 }
 
 type _PreHelpState struct {
@@ -197,6 +200,11 @@ Searching
 * Search is case sensitive if it contains any UPPER CASE CHARACTERS
 * Search is interpreted as a regexp if it is a valid one
 
+Customizing Key Bindings
+------------------------
+Key bindings can be customized — run 'moor --print-default-keybindings'
+to see the defaults, then redirect to ~/.config/moor/keybindings and edit.
+
 Reporting bugs
 --------------
 File issues at https://github.com/walles/moor/issues, or post
@@ -250,6 +258,9 @@ func NewPager(readers ...*reader.ReaderImpl) *Pager {
 
 	searchHistory := BootSearchHistory("")
 	pager.searchHistory = &searchHistory
+
+	// Initialize with default keybindings
+	pager.ModeBindings = DefaultModeBindings()
 
 	return &pager
 }
@@ -377,6 +388,115 @@ func (p *Pager) Quit() {
 	p.leftColumnZeroBased = p.preHelpState.leftColumnZeroBased
 	p.setTargetLine(p.preHelpState.targetLine)
 	p.preHelpState = nil
+}
+
+// commonActionHandlers is the single source of truth for which actions are
+// "common" (available in every mode). The map keys define the set; the values
+// execute the action.
+var commonActionHandlers = map[Action]func(*Pager){
+	Quit: func(p *Pager) {
+		p.Quit()
+	},
+	Reload: func(p *Pager) {
+		p.ReloadCurrentReader()
+	},
+	Edit: func(p *Pager) {
+		handleEditingRequest(p)
+	},
+	Help: func(p *Pager) {
+		if p.isShowingHelp {
+			return
+		}
+		p.preHelpState = &_PreHelpState{
+			scrollPosition:      p.scrollPosition,
+			leftColumnZeroBased: p.leftColumnZeroBased,
+			targetLine:          p.TargetLine,
+		}
+		p.scrollPosition = newScrollPosition("Pager scroll position")
+		p.leftColumnZeroBased = 0
+		p.setTargetLine(nil)
+		p.isShowingHelp = true
+	},
+	ToggleStatusBar: func(p *Pager) {
+		p.ShowStatusBar = !p.ShowStatusBar
+	},
+	ScrollUp: func(p *Pager) {
+		// Clipping is done in _Redraw()
+		p.scrollPosition = p.scrollPosition.PreviousLine(1)
+		p.handleScrolledUp()
+	},
+	ScrollDown: func(p *Pager) {
+		// Clipping is done in _Redraw()
+		p.scrollPosition = p.scrollPosition.NextLine(1)
+		p.handleScrolledDown()
+	},
+	ScrollTop: func(p *Pager) {
+		p.scrollPosition = newScrollPosition("Pager scroll position")
+		p.handleScrolledUp()
+	},
+	ScrollBottom: func(p *Pager) {
+		p.scrollToEnd()
+	},
+	ScrollPageDown: func(p *Pager) {
+		p.scrollPosition = p.scrollPosition.NextLine(p.visibleHeight())
+		p.handleScrolledDown()
+	},
+	ScrollPageUp: func(p *Pager) {
+		p.scrollPosition = p.scrollPosition.PreviousLine(p.visibleHeight())
+		p.handleScrolledUp()
+	},
+	ScrollHalfPageDown: func(p *Pager) {
+		p.scrollPosition = p.scrollPosition.NextLine(p.visibleHeight() / 2)
+		p.handleScrolledDown()
+	},
+	ScrollHalfPageUp: func(p *Pager) {
+		p.scrollPosition = p.scrollPosition.PreviousLine(p.visibleHeight() / 2)
+		p.handleScrolledUp()
+	},
+	ScrollRight: func(p *Pager) {
+		p.moveRight(p.SideScrollAmount)
+	},
+	ScrollLeft: func(p *Pager) {
+		p.moveRight(-p.SideScrollAmount)
+	},
+	ScrollRight1: func(p *Pager) {
+		p.moveRight(1)
+	},
+	ScrollLeft1: func(p *Pager) {
+		p.moveRight(-1)
+	},
+	ScrollHome: func(p *Pager) {
+		p.leftColumnZeroBased = 0
+		if !p.showLineNumbers {
+			// Line numbers not visible, turn them on if the user wants them.
+			p.showLineNumbers = p.ShowLineNumbers
+		}
+	},
+	ToggleWrap: func(p *Pager) {
+		p.WrapLongLines = !p.WrapLongLines
+		if p.WrapLongLines {
+			p.mode = &PagerModeInfo{Pager: p, Text: "Word wrapping enabled"}
+		} else {
+			p.mode = &PagerModeInfo{Pager: p, Text: "Word wrapping disabled"}
+		}
+	},
+	CycleTabSize: func(p *Pager) {
+		p.cycleTabSize()
+	},
+}
+
+// executeCommonAction handles actions that are common across all modes.
+// Returns true if the action was handled, false otherwise.
+func (p *Pager) executeCommonAction(action Action) bool {
+	if action == NoAction {
+		return true
+	}
+	handler, ok := commonActionHandlers[action]
+	if !ok {
+		return false
+	}
+	handler(p)
+	return true
 }
 
 // Negative deltas move left instead

--- a/internal/pager_test.go
+++ b/internal/pager_test.go
@@ -670,7 +670,7 @@ func testFooter(t *testing.T, filename string, contents string, expectedFooter s
 }
 
 func TestFooter(t *testing.T) {
-	help := "Press ESC / q to exit, / to search, & to filter, h for help"
+	help := "Press escape to exit, / to search, & to filter, h for help"
 
 	testFooter(t, "filename", "", "filename: <empty>  "+help)
 	testFooter(t, "", "", "<empty>  "+help)

--- a/internal/pagermode-colon-command.go
+++ b/internal/pagermode-colon-command.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"fmt"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/walles/moor/v2/twin"
 )
@@ -14,8 +16,13 @@ func (m *PagerModeColonCommand) drawFooter(_ string, _ string, _ string) {
 	_, screenHeight := p.ScreenSize()
 	height := int(screenHeight)
 
+	nextKey := keyForAction(p.ModeBindings.ColonCommand, NextFile)
+	prevKey := keyForAction(p.ModeBindings.ColonCommand, PreviousFile)
+	firstKey := keyForAction(p.ModeBindings.ColonCommand, FirstFile)
+	prompt := fmt.Sprintf("Go to next [%s], previous [%s] or first [%s] file: ", nextKey, prevKey, firstKey)
+
 	pos := 0
-	for _, token := range "Go to [n]ext, [p]revious or first [x] file: " {
+	for _, token := range prompt {
 		pos += p.screen.SetCell(pos, height-1, twin.NewStyledRune(token, twin.StyleDefault))
 	}
 
@@ -23,45 +30,65 @@ func (m *PagerModeColonCommand) drawFooter(_ string, _ string, _ string) {
 	p.screen.SetCell(pos, height-1, twin.NewStyledRune(' ', twin.StyleDefault.WithAttr(twin.AttrReverse)))
 }
 
-func (m *PagerModeColonCommand) onKey(key twin.KeyCode) {
+func (m *PagerModeColonCommand) executeAction(action Action) {
 	p := m.pager
 
-	switch key {
-	case twin.KeyEscape:
+	switch action {
+	case Cancel:
 		p.mode = PagerModeViewing{pager: p}
+		return
 
-	default:
-		log.Tracef("Unhandled colon command event %v, treating as a viewing key event", key)
-		p.mode = PagerModeViewing{pager: p}
-		p.mode.onKey(key)
-	}
-}
-
-func (m *PagerModeColonCommand) onRune(char rune) {
-	p := m.pager
-
-	if char == 'q' {
-		// Back to viewing mode, just like ESC
-		p.mode = PagerModeViewing{pager: p}
-	}
-
-	if char == 'p' {
+	case PreviousFile:
 		p.mode = PagerModeViewing{pager: p}
 		p.previousFile()
 		return
-	}
 
-	if char == 'n' {
+	case NextFile:
 		p.mode = PagerModeViewing{pager: p}
 		p.nextFile()
 		return
-	}
 
-	if char == 'x' {
+	case FirstFile:
 		p.mode = PagerModeViewing{pager: p}
 		p.firstFile()
 		return
 	}
 
+	// Try common actions
+	if p.executeCommonAction(action) {
+		return
+	}
+
+	// Action not handled
+	log.Debugf("Unhandled colon command action: %v", action)
+}
+
+func (m *PagerModeColonCommand) onKey(key twin.KeyCode) {
+	p := m.pager
+
+	// Look up action from keybindings
+	action, found := p.ModeBindings.ColonCommand.KeyCodeBindings[key]
+	if found {
+		m.executeAction(action)
+		return
+	}
+
+	// No action bound, fall through to viewing mode
+	log.Tracef("Unhandled colon command event %v, treating as a viewing key event", key)
+	p.mode = PagerModeViewing{pager: p}
+	p.mode.onKey(key)
+}
+
+func (m *PagerModeColonCommand) onRune(char rune) {
+	p := m.pager
+
+	// Look up action from keybindings
+	action, found := p.ModeBindings.ColonCommand.RuneBindings[char]
+	if found {
+		m.executeAction(action)
+		return
+	}
+
+	// No action bound, ignore it
 	log.Debugf("Unhandled colon command rune %q, ignoring it", char)
 }

--- a/internal/pagermode-filter.go
+++ b/internal/pagermode-filter.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"fmt"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/walles/moor/v2/internal/search"
 	"github.com/walles/moor/v2/twin"
@@ -15,17 +17,18 @@ func NewPagerModeFilter(p *Pager) *PagerModeFilter {
 	m := &PagerModeFilter{
 		pager: p,
 	}
-	m.inputBox = &InputBox{
-		accept: INPUTBOX_ACCEPT_ALL,
-		onTextChanged: func(text string) {
-			m.updateFilterPattern(text)
-		},
+	m.inputBox = NewInputBox(INPUTBOX_ACCEPT_ALL, p.ModeBindings.Input)
+	m.inputBox.onTextChanged = func(text string) {
+		m.updateFilterPattern(text)
 	}
 	return m
 }
 
 func (m PagerModeFilter) drawFooter(_ string, _ string, _ string) {
-	m.inputBox.draw(m.pager.screen, "Type to filter, 'ENTER' submits, 'ESC' cancels", "Filter: ")
+	acceptKey := keyForAction(m.pager.ModeBindings.Filter, Accept)
+	cancelKey := keyForAction(m.pager.ModeBindings.Filter, Cancel)
+	hint := fmt.Sprintf("Type to filter, '%s' submits, '%s' cancels", acceptKey, cancelKey)
+	m.inputBox.draw(m.pager.screen, hint, "Filter: ")
 }
 
 func (m *PagerModeFilter) updateFilterPattern(text string) {
@@ -33,29 +36,51 @@ func (m *PagerModeFilter) updateFilterPattern(text string) {
 	m.pager.search.For(text)
 }
 
+func (m *PagerModeFilter) executeAction(action Action) {
+	switch action {
+	case Accept:
+		m.pager.mode = PagerModeViewing{pager: m.pager}
+		return
+
+	case Cancel:
+		m.pager.mode = PagerModeViewing{pager: m.pager}
+		m.pager.filter = search.Search{}
+		m.pager.search.Clear()
+		return
+	}
+
+	// Try common actions
+	if m.pager.executeCommonAction(action) {
+		return
+	}
+
+	// Action not handled
+	log.Debugf("Unhandled filter action: %v", action)
+}
+
 func (m *PagerModeFilter) onKey(key twin.KeyCode) {
+	// Check keybindings first (priority over InputBox)
+	if action, found := m.pager.ModeBindings.Filter.KeyCodeBindings[key]; found {
+		m.executeAction(action)
+		return
+	}
+
+	// Fall back to InputBox handling
 	if m.inputBox.handleKey(key) {
 		return
 	}
 
-	switch key {
-	case twin.KeyEnter:
-		m.pager.mode = PagerModeViewing{pager: m.pager}
-
-	case twin.KeyEscape:
-		m.pager.mode = PagerModeViewing{pager: m.pager}
-		m.pager.filter = search.Search{}
-		m.pager.search.Clear()
-
-	case twin.KeyUp, twin.KeyDown, twin.KeyPgUp, twin.KeyPgDown:
-		viewing := PagerModeViewing{pager: m.pager}
-		viewing.onKey(key)
-
-	default:
-		log.Debugf("Unhandled filter key event %v", key)
-	}
+	log.Debugf("Unhandled filter key event %v", key)
 }
 
 func (m *PagerModeFilter) onRune(char rune) {
+	// Look up action from keybindings
+	action, found := m.pager.ModeBindings.Filter.RuneBindings[char]
+	if found {
+		m.executeAction(action)
+		return
+	}
+
+	// Unbound rune - fallthrough to text input
 	m.inputBox.handleRune(char)
 }

--- a/internal/pagermode-go-to-line.go
+++ b/internal/pagermode-go-to-line.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"fmt"
 	"strconv"
 
 	log "github.com/sirupsen/logrus"
@@ -15,17 +16,17 @@ type PagerModeGotoLine struct {
 
 func NewPagerModeGotoLine(p *Pager) *PagerModeGotoLine {
 	m := &PagerModeGotoLine{
-		pager: p,
-		inputBox: InputBox{
-			accept:        INPUTBOX_ACCEPT_POSITIVE_NUMBERS,
-			onTextChanged: nil,
-		},
+		pager:    p,
+		inputBox: *NewInputBox(INPUTBOX_ACCEPT_POSITIVE_NUMBERS, p.ModeBindings.Input),
 	}
 	return m
 }
 
 func (m *PagerModeGotoLine) drawFooter(_ string, _ string, _ string) {
-	m.inputBox.draw(m.pager.screen, "'ENTER' submits, 'ESC' cancels", "Go to line number: ")
+	acceptKey := keyForAction(m.pager.ModeBindings.GotoLine, Accept)
+	cancelKey := keyForAction(m.pager.ModeBindings.GotoLine, Cancel)
+	hint := fmt.Sprintf("'%s' submits, '%s' cancels", acceptKey, cancelKey)
+	m.inputBox.draw(m.pager.screen, hint, "Go to line number: ")
 }
 
 func (m *PagerModeGotoLine) updateLineNumber(text string) {
@@ -46,40 +47,62 @@ func (m *PagerModeGotoLine) updateLineNumber(text string) {
 	m.pager.setTargetLine(&targetIndex)
 }
 
+func (m *PagerModeGotoLine) executeAction(action Action) {
+	switch action {
+	case Accept:
+		m.updateLineNumber(m.inputBox.text)
+		m.pager.mode = PagerModeViewing{pager: m.pager}
+		return
+
+	case Cancel:
+		m.pager.mode = PagerModeViewing{pager: m.pager}
+		return
+
+	case GotoTop:
+		m.pager.scrollPosition = newScrollPosition("Pager scroll position")
+		m.pager.handleScrolledUp()
+		m.pager.mode = PagerModeViewing{pager: m.pager}
+		return
+
+	}
+
+	// Try common actions
+	if m.pager.executeCommonAction(action) {
+		return
+	}
+
+	// Action not handled
+	log.Debugf("Unhandled goto-line action: %v", action)
+}
+
 func (m *PagerModeGotoLine) onKey(key twin.KeyCode) {
+	p := m.pager
+
+	// Check keybindings first (priority over InputBox)
+	if action, found := p.ModeBindings.GotoLine.KeyCodeBindings[key]; found {
+		m.executeAction(action)
+		return
+	}
+
+	// Fall back to InputBox handling
 	if m.inputBox.handleKey(key) {
 		return
 	}
 
-	switch key {
-	case twin.KeyEnter:
-		m.updateLineNumber(m.inputBox.text)
-		m.pager.mode = PagerModeViewing{pager: m.pager}
-
-	case twin.KeyEscape:
-		m.pager.mode = PagerModeViewing{pager: m.pager}
-
-	default:
-		log.Tracef("Unhandled goto key event %v, treating as a viewing key event", key)
-		m.pager.mode = PagerModeViewing{pager: m.pager}
-		m.pager.mode.onKey(key)
-	}
+	// No action bound, fall through to viewing mode
+	log.Tracef("Unhandled goto-line key event %v, treating as a viewing key event", key)
+	p.mode = PagerModeViewing{pager: p}
+	p.mode.onKey(key)
 }
 
 func (m *PagerModeGotoLine) onRune(char rune) {
-	p := m.pager
-
-	if char == 'q' {
-		p.mode = PagerModeViewing{pager: p}
+	// Look up action from keybindings
+	action, found := m.pager.ModeBindings.GotoLine.RuneBindings[char]
+	if found {
+		m.executeAction(action)
 		return
 	}
 
-	if char == 'g' {
-		p.scrollPosition = newScrollPosition("Pager scroll position")
-		p.handleScrolledUp()
-		p.mode = PagerModeViewing{pager: p}
-		return
-	}
-
+	// Unbound rune - fallthrough to number input
 	m.inputBox.handleRune(char)
 }

--- a/internal/pagermode-jump-to-mark.go
+++ b/internal/pagermode-jump-to-mark.go
@@ -1,8 +1,10 @@
 package internal
 
 import (
+	"fmt"
 	"sort"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/walles/moor/v2/twin"
 	"golang.org/x/exp/maps"
 )
@@ -26,7 +28,8 @@ func (m PagerModeJumpToMark) drawFooter(_ string, _ string, _ string) {
 func (m PagerModeJumpToMark) getMarkPrompt() string {
 	// Special case having zero, one or multiple marks
 	if len(m.pager.bookmarks) == 0 {
-		return "No marks set, press 'm' to set one!"
+		markKey := keyForAction(m.pager.ModeBindings.Viewing, Mark)
+		return fmt.Sprintf("No marks set, press '%s' to set one!", markKey)
 	}
 
 	if len(m.pager.bookmarks) == 1 {
@@ -52,31 +55,63 @@ func (m PagerModeJumpToMark) getMarkPrompt() string {
 	return prompt
 }
 
-func (m PagerModeJumpToMark) onKey(key twin.KeyCode) {
+func (m PagerModeJumpToMark) executeAction(action Action) {
 	p := m.pager
 
-	switch key {
-	case twin.KeyEnter, twin.KeyEscape:
-		// Never mind I
+	switch action {
+	case Accept:
+		if len(p.bookmarks) == 1 {
+			for char, destination := range p.bookmarks {
+				log.Debugf("Jumping to mark '%s'", string(char))
+				p.scrollPosition = destination
+			}
+			p.mode = PagerModeViewing{pager: p}
+		}
+		return
+	case Cancel:
 		p.mode = PagerModeViewing{pager: p}
-
-	default:
-		// Never mind II
-		p.mode = PagerModeViewing{pager: p}
-		p.mode.onKey(key)
-	}
-}
-
-func (m PagerModeJumpToMark) onRune(char rune) {
-	if len(m.pager.bookmarks) == 0 && char == 'm' {
-		m.pager.mode = PagerModeMark(m)
 		return
 	}
 
-	destination, ok := m.pager.bookmarks[char]
-	if ok {
-		m.pager.scrollPosition = destination
+	// Try common actions
+	if p.executeCommonAction(action) {
+		return
 	}
 
-	m.pager.mode = PagerModeViewing(m)
+	// Action not handled
+	log.Debugf("Unhandled jump-to-mark action: %v", action)
+}
+
+func (m PagerModeJumpToMark) onKey(key twin.KeyCode) {
+	p := m.pager
+
+	action, found := p.ModeBindings.JumpToMark.KeyCodeBindings[key]
+	if found {
+		m.executeAction(action)
+		return
+	}
+
+	// No action bound, fall through to viewing mode
+	log.Tracef("Unhandled jump-to-mark key event %v, treating as a viewing key event", key)
+	p.mode = PagerModeViewing{pager: p}
+	p.mode.onKey(key)
+}
+
+func (m PagerModeJumpToMark) onRune(char rune) {
+	p := m.pager
+
+	if len(p.bookmarks) == 0 {
+		if action, found := p.ModeBindings.Viewing.RuneBindings[char]; found && action == Mark {
+			p.mode = PagerModeMark(m)
+			return
+		}
+	}
+
+	destination, ok := p.bookmarks[char]
+	if ok {
+		log.Debugf("Jumping to mark '%s'", string(char))
+		p.scrollPosition = destination
+	}
+
+	p.mode = PagerModeViewing(m)
 }

--- a/internal/pagermode-mark.go
+++ b/internal/pagermode-mark.go
@@ -1,6 +1,9 @@
 package internal
 
-import "github.com/walles/moor/v2/twin"
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/walles/moor/v2/twin"
+)
 
 type PagerModeMark struct {
 	pager *Pager
@@ -21,22 +24,41 @@ func (m PagerModeMark) drawFooter(_ string, _ string, _ string) {
 	p.screen.SetCell(pos, height-1, twin.NewStyledRune(' ', twin.StyleDefault.WithAttr(twin.AttrReverse)))
 }
 
+func (m PagerModeMark) executeAction(action Action) {
+	p := m.pager
+
+	switch action {
+	case Cancel:
+		p.mode = PagerModeViewing{pager: p}
+		return
+	}
+
+	// Try common actions (including NoAction)
+	if p.executeCommonAction(action) {
+		return
+	}
+
+	// Action not handled
+	log.Debugf("Unhandled mark action: %v", action)
+}
+
 func (m PagerModeMark) onKey(key twin.KeyCode) {
 	p := m.pager
 
-	switch key {
-	case twin.KeyEnter, twin.KeyEscape:
-		// Never mind I
-		p.mode = PagerModeViewing{pager: p}
-
-	default:
-		// Never mind II
-		p.mode = PagerModeViewing{pager: p}
-		p.mode.onKey(key)
+	action, found := p.ModeBindings.Mark.KeyCodeBindings[key]
+	if found {
+		m.executeAction(action)
+		return
 	}
+
+	// No action bound, fall through to viewing mode
+	log.Tracef("Unhandled mark key event %v, treating as a viewing key event", key)
+	p.mode = PagerModeViewing{pager: p}
+	p.mode.onKey(key)
 }
 
 func (m PagerModeMark) onRune(char rune) {
+	log.Debugf("Setting mark '%s' at %v", string(char), m.pager.scrollPosition)
 	m.pager.bookmarks[char] = m.pager.scrollPosition
 	m.pager.mode = PagerModeViewing(m)
 }

--- a/internal/pagermode-not-found.go
+++ b/internal/pagermode-not-found.go
@@ -1,6 +1,9 @@
 package internal
 
-import "github.com/walles/moor/v2/twin"
+import (
+	log "github.com/sirupsen/logrus"
+	"github.com/walles/moor/v2/twin"
+)
 
 type PagerModeNotFound struct {
 	pager *Pager
@@ -11,23 +14,41 @@ func (m PagerModeNotFound) drawFooter(_ string, _ string, _ string) {
 }
 
 func (m PagerModeNotFound) onKey(key twin.KeyCode) {
-	m.pager.mode = PagerModeViewing(m)
-	m.pager.mode.onKey(key)
+	action, found := m.pager.ModeBindings.NotFound.KeyCodeBindings[key]
+	if !found {
+		action, found = m.pager.ModeBindings.Viewing.KeyCodeBindings[key]
+	}
+	if found {
+		m.executeAction(action)
+		return
+	}
+	log.Debugf("Unhandled not-found key event %v", key)
 }
 
 func (m PagerModeNotFound) onRune(char rune) {
-	switch char {
+	action, found := m.pager.ModeBindings.NotFound.RuneBindings[char]
+	if !found {
+		action, found = m.pager.ModeBindings.Viewing.RuneBindings[char]
+	}
+	if found {
+		m.executeAction(action)
+		return
+	}
+	log.Debugf("Unhandled not-found rune '%s'/0x%08x", string(char), int32(char))
+}
 
-	// Should match the pagermode-viewing.go next-search-hit bindings
-	case 'n':
-		m.pager.scrollToNextSearchHit()
-
-	// Should match the pagermode-viewing.go previous-search-hit bindings
-	case 'p', 'N':
-		m.pager.scrollToPreviousSearchHit()
-
-	default:
+func (m PagerModeNotFound) executeAction(action Action) {
+	switch action {
+	case NextSearchHit:
 		m.pager.mode = PagerModeViewing(m)
-		m.pager.mode.onRune(char)
+		m.pager.scrollToNextSearchHit(true)
+	case PreviousSearchHit:
+		m.pager.mode = PagerModeViewing(m)
+		m.pager.scrollToPreviousSearchHit(true)
+	default:
+		// For all other actions, switch to viewing mode and execute there.
+		viewing := PagerModeViewing(m)
+		m.pager.mode = viewing
+		viewing.executeAction(action)
 	}
 }

--- a/internal/pagermode-search.go
+++ b/internal/pagermode-search.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"fmt"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/walles/moor/v2/twin"
 )
@@ -28,18 +30,16 @@ func NewPagerModeSearch(p *Pager, direction SearchDirection, initialScrollPositi
 		direction:             direction,
 		searchHistoryIndex:    len(p.searchHistory.entries), // Past the end
 	}
-	m.inputBox = &InputBox{
-		accept: INPUTBOX_ACCEPT_ALL,
-		onTextChanged: func(text string) {
-			m.pager.search.For(text)
+	m.inputBox = NewInputBox(INPUTBOX_ACCEPT_ALL, p.ModeBindings.Input)
+	m.inputBox.onTextChanged = func(text string) {
+		m.pager.search.For(text)
 
-			switch m.direction {
-			case SearchDirectionBackward:
-				m.pager.scrollToSearchHitsBackwards()
-			case SearchDirectionForward:
-				m.pager.scrollToSearchHits()
-			}
-		},
+		switch m.direction {
+		case SearchDirectionBackward:
+			m.pager.scrollToSearchHitsBackwards()
+		case SearchDirectionForward:
+			m.pager.scrollToSearchHits()
+		}
 	}
 	return m
 }
@@ -49,7 +49,13 @@ func (m PagerModeSearch) drawFooter(_ string, _ string, _ string) {
 	if m.direction == SearchDirectionBackward {
 		prompt = "Search backwards: "
 	}
-	m.inputBox.draw(m.pager.screen, "Type to search, 'ENTER' submits, 'ESC' cancels, '↑↓' navigate history", prompt)
+	acceptKey := keyForAction(m.pager.ModeBindings.Search, Accept)
+	cancelKey := keyForAction(m.pager.ModeBindings.Search, Cancel)
+	histPrevKey := keyForAction(m.pager.ModeBindings.Search, HistoryPrevious)
+	histNextKey := keyForAction(m.pager.ModeBindings.Search, HistoryNext)
+	hint := fmt.Sprintf("Type to search, '%s' submits, '%s' cancels, '%s'/'%s' navigate history",
+		acceptKey, cancelKey, histPrevKey, histNextKey)
+	m.inputBox.draw(m.pager.screen, hint, prompt)
 }
 
 func (m *PagerModeSearch) moveSearchHistoryIndex(delta int) {
@@ -74,54 +80,72 @@ func (m *PagerModeSearch) moveSearchHistoryIndex(delta int) {
 	}
 }
 
-// Exit search mode, skip back to where we started
-func (m *PagerModeSearch) abort() {
-	m.pager.searchHistory.addEntry(m.inputBox.text)
-	m.pager.mode = PagerModeViewing{pager: m.pager}
-	m.pager.scrollPosition = m.initialScrollPosition
-	m.pager.setTargetLine(nil) // Viewing doesn't need all lines
+func (m *PagerModeSearch) executeAction(action Action) {
+	// Handle search-specific actions first
+	switch action {
+	case Accept:
+		m.pager.searchHistory.addEntry(m.inputBox.text)
+		m.pager.mode = PagerModeViewing{pager: m.pager}
+		m.pager.setTargetLine(nil) // Viewing doesn't need all lines
+		return
+
+	case Cancel:
+		m.pager.searchHistory.addEntry(m.inputBox.text)
+		m.pager.mode = PagerModeViewing{pager: m.pager}
+		m.pager.scrollPosition = m.initialScrollPosition
+		m.pager.setTargetLine(nil) // Viewing doesn't need all lines
+		return
+
+	case ScrollPageUp, ScrollPageDown:
+		m.pager.searchHistory.addEntry(m.inputBox.text)
+		m.pager.mode = PagerModeViewing{pager: m.pager}
+		m.pager.executeCommonAction(action)
+		m.pager.setTargetLine(nil) // Viewing doesn't need all lines
+		return
+
+	case HistoryPrevious:
+		m.moveSearchHistoryIndex(-1)
+		return
+
+	case HistoryNext:
+		m.moveSearchHistoryIndex(1)
+		return
+	}
+
+	// Try common actions
+	if m.pager.executeCommonAction(action) {
+		return
+	}
+
+	// Action not handled
+	log.Debugf("Unhandled search action %v", action)
 }
 
 func (m *PagerModeSearch) onKey(key twin.KeyCode) {
+	// Check keybindings first (priority over InputBox)
+	if action, found := m.pager.ModeBindings.Search.KeyCodeBindings[key]; found {
+		m.executeAction(action)
+		return
+	}
+
+	// Fall back to InputBox handling
 	if m.inputBox.handleKey(key) {
 		m.searchHistoryIndex = len(m.pager.searchHistory.entries) // Reset history index when user types
 		m.userEditedText = m.inputBox.text
 		return
 	}
 
-	switch key {
-	case twin.KeyEnter:
-		m.pager.searchHistory.addEntry(m.inputBox.text)
-		m.pager.mode = PagerModeViewing{pager: m.pager}
-		m.pager.setTargetLine(nil) // Viewing doesn't need all lines
-
-	case twin.KeyEscape:
-		m.abort()
-
-	case twin.KeyPgUp, twin.KeyPgDown:
-		m.pager.searchHistory.addEntry(m.inputBox.text)
-		m.pager.mode = PagerModeViewing{pager: m.pager}
-		m.pager.mode.onKey(key)
-		m.pager.setTargetLine(nil) // Viewing doesn't need all lines
-
-	case twin.KeyUp:
-		m.moveSearchHistoryIndex(-1)
-
-	case twin.KeyDown:
-		m.moveSearchHistoryIndex(1)
-
-	default:
-		log.Debugf("Unhandled search key event %v", key)
-	}
+	log.Debugf("Unhandled search key event %v", key)
 }
 
 func (m *PagerModeSearch) onRune(char rune) {
-	// Handle ctrl-c
-	if char == '\x03' {
-		m.abort()
+	// Lookup action from keybindings
+	if action, found := m.pager.ModeBindings.Search.RuneBindings[char]; found {
+		m.executeAction(action)
 		return
 	}
 
+	// Unbound rune - insert into search box
 	m.searchHistoryIndex = len(m.pager.searchHistory.entries) // Reset history index when user types
 	m.inputBox.handleRune(char)
 	m.userEditedText = m.inputBox.text

--- a/internal/pagermode-viewing.go
+++ b/internal/pagermode-viewing.go
@@ -20,18 +20,27 @@ func (m PagerModeViewing) drawFooter(filenameText string, statusText string, spi
 	m.pager.readerLock.Lock()
 	if len(m.pager.readers) > 1 {
 		prefix = fmt.Sprintf("[%d/%d] ", m.pager.currentReader+1, len(m.pager.readers))
-		colonHelp = "':' to switch, "
+		colonKey := keyForAction(m.pager.ModeBindings.Viewing, ColonCommand)
+		colonHelp = fmt.Sprintf("'%s' to switch, ", colonKey)
 	}
 	m.pager.readerLock.Unlock()
 
-	searchHelp := "'/' to search"
+	vb := m.pager.ModeBindings.Viewing
+	quitKey := keyForAction(vb, Quit)
+	filterKey := keyForAction(vb, Filter)
+	helpKey := keyForAction(vb, Help)
+	searchKey := keyForAction(vb, SearchForward)
+	nextKey := keyForAction(vb, NextSearchHit)
+	prevKey := keyForAction(vb, PreviousSearchHit)
+
+	searchHelp := fmt.Sprintf("'%s' to search", searchKey)
 	if !m.pager.search.Inactive() {
-		searchHelp = "'n'/'p' to search next/previous"
+		searchHelp = fmt.Sprintf("'%s'/'%s' to search next/previous", nextKey, prevKey)
 	}
-	helpText := "Press 'ESC' / 'q' to exit, " + colonHelp + searchHelp + ", '&' to filter, 'h' for help"
+	helpText := fmt.Sprintf("Press '%s' to exit, ", quitKey) + colonHelp + searchHelp + fmt.Sprintf(", '%s' to filter, '%s' for help", filterKey, helpKey)
 
 	if m.pager.isShowingHelp {
-		helpText = "Press 'ESC' / 'q' to exit help, " + searchHelp
+		helpText = fmt.Sprintf("Press '%s' to exit help, ", quitKey) + searchHelp
 		prefix = ""
 	}
 
@@ -44,131 +53,34 @@ func (m PagerModeViewing) drawFooter(filenameText string, statusText string, spi
 }
 
 func (m PagerModeViewing) onKey(keyCode twin.KeyCode) {
-	p := m.pager
-
-	switch keyCode {
-	case twin.KeyEscape:
-		p.Quit()
-
-	case twin.KeyUp:
-		// Clipping is done in _Redraw()
-		p.scrollPosition = p.scrollPosition.PreviousLine(1)
-		p.handleScrolledUp()
-
-	case twin.KeyDown, twin.KeyEnter:
-		// Clipping is done in _Redraw()
-		p.scrollPosition = p.scrollPosition.NextLine(1)
-		p.handleScrolledDown()
-
-	case twin.KeyRight:
-		p.moveRight(p.SideScrollAmount)
-
-	case twin.KeyLeft:
-		p.moveRight(-p.SideScrollAmount)
-
-	case twin.KeyAltRight:
-		p.moveRight(1)
-
-	case twin.KeyAltLeft:
-		p.moveRight(-1)
-
-	case twin.KeyHome:
-		p.scrollPosition = newScrollPosition("Pager scroll position")
-		p.handleScrolledUp()
-
-	case twin.KeyEnd:
-		p.scrollToEnd()
-
-	case twin.KeyPgUp:
-		p.scrollPosition = p.scrollPosition.PreviousLine(p.visibleHeight())
-		p.handleScrolledUp()
-
-	case twin.KeyPgDown:
-		p.scrollPosition = p.scrollPosition.NextLine(p.visibleHeight())
-		p.handleScrolledDown()
-
-	default:
-		log.Debugf("Unhandled key event %v", keyCode)
+	action, found := m.pager.ModeBindings.Viewing.KeyCodeBindings[keyCode]
+	if found {
+		m.executeAction(action)
+		return
 	}
+	log.Debugf("Unhandled viewing key event %v", keyCode)
 }
 
 func (m PagerModeViewing) onRune(char rune) {
+	action, found := m.pager.ModeBindings.Viewing.RuneBindings[char]
+	if found {
+		m.executeAction(action)
+		return
+	}
+	log.Debugf("Unhandled viewing rune keypress '%s'/0x%08x", string(char), int32(char))
+}
+
+func (m PagerModeViewing) executeAction(action Action) {
 	p := m.pager
 
-	switch char {
-	case 'q':
-		p.Quit()
+	// Try to execute as common action first
+	if p.executeCommonAction(action) {
+		return
+	}
 
-	case 'r':
-		p.ReloadCurrentReader()
-
-	case 'v':
-		handleEditingRequest(p)
-
-	case 'h':
-		if p.isShowingHelp {
-			break
-		}
-
-		p.preHelpState = &_PreHelpState{
-			scrollPosition:      p.scrollPosition,
-			leftColumnZeroBased: p.leftColumnZeroBased,
-			targetLine:          p.TargetLine,
-		}
-		p.scrollPosition = newScrollPosition("Pager scroll position")
-		p.leftColumnZeroBased = 0
-		p.setTargetLine(nil)
-		p.isShowingHelp = true
-
-	case '=':
-		p.ShowStatusBar = !p.ShowStatusBar
-
-	// '\x10' = CTRL-p, should scroll up one line.
-	// Ref: https://github.com/walles/moor/issues/107#issuecomment-1328354080
-	case 'k', 'y', '\x10':
-		// Clipping is done in _Redraw()
-		p.scrollPosition = p.scrollPosition.PreviousLine(1)
-		p.handleScrolledUp()
-
-	// '\x0e' = CTRL-n, should scroll down one line.
-	// Ref: https://github.com/walles/moor/issues/107#issuecomment-1328354080
-	case 'j', 'e', '\x0e':
-		// Clipping is done in _Redraw()
-		p.scrollPosition = p.scrollPosition.NextLine(1)
-		p.handleScrolledDown()
-
-	case '<':
-		p.scrollPosition = newScrollPosition("Pager scroll position")
-		p.handleScrolledUp()
-
-	case '>', 'G':
-		p.scrollToEnd()
-
-	// '\x06' = CTRL-f, should work like just 'f'.
-	// Ref: https://github.com/walles/moor/issues/107
-	case 'f', ' ', '\x06':
-		p.scrollPosition = p.scrollPosition.NextLine(p.visibleHeight())
-		p.handleScrolledDown()
-
-	// '\x02' = CTRL-b, should work like just 'b'.
-	// Ref: https://github.com/walles/moor/issues/107
-	case 'b', '\x02':
-		p.scrollPosition = p.scrollPosition.PreviousLine(p.visibleHeight())
-		p.handleScrolledUp()
-
-	// '\x15' = CTRL-u, should work like just 'u'.
-	// Ref: https://github.com/walles/moor/issues/90
-	case 'u', '\x15':
-		p.scrollPosition = p.scrollPosition.PreviousLine(p.visibleHeight() / 2)
-		p.handleScrolledUp()
-
-	// '\x04' = CTRL-d, should work like just 'd'.
-	// Ref: https://github.com/walles/moor/issues/90
-	case 'd', '\x04':
-		p.scrollPosition = p.scrollPosition.NextLine(p.visibleHeight() / 2)
-		p.handleScrolledDown()
-
-	case '/':
+	// Handle viewing-specific actions (mode switches)
+	switch action {
+	case SearchForward:
 		p.mode = NewPagerModeSearch(p, SearchDirectionForward, p.scrollPosition)
 		p.search.Clear()
 
@@ -176,7 +88,7 @@ func (m PagerModeViewing) onRune(char rune) {
 		reallyHigh := linemetadata.IndexMax()
 		p.setTargetLine(&reallyHigh)
 
-	case '?':
+	case SearchBackward:
 		p.mode = NewPagerModeSearch(p, SearchDirectionBackward, p.scrollPosition)
 		p.search.Clear()
 
@@ -184,7 +96,7 @@ func (m PagerModeViewing) onRune(char rune) {
 		reallyHigh := linemetadata.IndexMax()
 		p.setTargetLine(&reallyHigh)
 
-	case '&':
+	case Filter:
 		if !p.isShowingHelp {
 			// Filtering the help text is not supported. Feel free to work on
 			// that if you feel that's time well spent.
@@ -193,11 +105,11 @@ func (m PagerModeViewing) onRune(char rune) {
 			p.filter = search.Search{}
 		}
 
-	case 'g':
+	case GotoLine:
 		p.mode = NewPagerModeGotoLine(p)
 		p.setTargetLine(nil)
 
-	case ':':
+	case ColonCommand:
 		if len(p.readers) > 1 {
 			p.mode = &PagerModeColonCommand{pager: p}
 			p.setTargetLine(nil)
@@ -205,42 +117,22 @@ func (m PagerModeViewing) onRune(char rune) {
 			p.mode = &PagerModeInfo{Pager: p, Text: "Pass more files on the command line to be able to switch between them."}
 		}
 
-	// Should match the pagermode-not-found.go previous-search-hit bindings
-	case 'n':
-		p.scrollToNextSearchHit()
+	case NextSearchHit:
+		p.scrollToNextSearchHit(false)
 
-	// Should match the pagermode-not-found.go next-search-hit bindings
-	case 'p', 'N':
-		p.scrollToPreviousSearchHit()
+	case PreviousSearchHit:
+		p.scrollToPreviousSearchHit(false)
 
-	case 'm':
+	case Mark:
 		p.mode = PagerModeMark{pager: p}
 		p.setTargetLine(nil)
 
-	case '\'':
+	case JumpToMark:
 		p.mode = PagerModeJumpToMark{pager: p}
 		p.setTargetLine(nil)
 
-	case 'w':
-		p.WrapLongLines = !p.WrapLongLines
-		if p.WrapLongLines {
-			p.mode = &PagerModeInfo{Pager: p, Text: "Word wrapping enabled"}
-		} else {
-			p.mode = &PagerModeInfo{Pager: p, Text: "Word wrapping disabled"}
-		}
-
-	case '\x14': // CTRL-t
-		p.cycleTabSize()
-
-	case '\x01': // CTRL-a
-		p.leftColumnZeroBased = 0
-		if !p.showLineNumbers {
-			// Line numbers not visible, turn them on if the user wants them.
-			p.showLineNumbers = p.ShowLineNumbers
-		}
-
 	default:
-		log.Debugf("Unhandled rune keypress '%s'/0x%08x", string(char), int32(char))
+		log.Debugf("Unhandled viewing action: %d", action)
 	}
 }
 

--- a/internal/pagermode-viewing_test.go
+++ b/internal/pagermode-viewing_test.go
@@ -53,7 +53,7 @@ func TestViewingFooter_WithSpinner(t *testing.T) {
 	footer := rowToString(screen.GetRow(9))
 
 	// Quotes are stripped in rendering; expect plain keys
-	expectedHelp := "Press ESC / q to exit, / to search, & to filter, h for help"
+	expectedHelp := "Press escape to exit, / to search, & to filter, h for help"
 	expected := "1 line  100%  " + spinner + "  " + expectedHelp
 
 	assert.Equal(t, expected, footer)

--- a/moor.1
+++ b/moor.1
@@ -49,6 +49,12 @@ Print debug logs after exiting, less verbose than
 Scrolls automatically to follow piped input, just like
 .B tail \-f
 .TP
+\fB\-\-keybindings\fR=file
+Path to a custom keybindings file.
+Run
+.B moor --print-default-keybindings
+to see the default keybindings and use them as a starting point.
+.TP
 \fB\-\-lang\fR=string
 Used for highlighting.
 Without this flag highlighting is based on the input file name.
@@ -79,6 +85,9 @@ Do not highlight the background of lines with search hits. The search hits thems
 \fB\-\-no\-statusbar\fR
 Hide the status bar, toggle with
 .B =
+.TP
+\fB\-\-print\-default\-keybindings\fR
+Print default keybindings to stdout and exit.
 .TP
 \fB\-\-quit\-if\-one\-screen\fR
 Print input contents without paging if the input fits on one screen.


### PR DESCRIPTION
Users can now customize keyboard shortcuts by placing a keybindings file at
`~/.config/moor/keybindings` (or `$XDG_CONFIG_HOME/moor/keybindings`).

### Usage

Print the built-in defaults as a ready-to-edit starting point:

```
moor --print-default-keybindings > ~/.config/moor/keybindings
```

Point moor at a specific file (errors are fatal):

```
moor --keybindings ~/my-keybindings somefile.txt
```

### File format

```ini
# Lines starting with # are comments; blank lines are ignored.
# Format: <key>  <action>
# Keys: a-z, A-Z, 0-9, special chars, ctrl-a…ctrl-z, escape, enter,
#       backspace, delete, up/down/left/right, home, end, pageup/pagedown,
#       alt-up/down/left/right, space
# Use 'noaction' to disable a key.

[viewing]
escape  quit
q       quit
j       scroll-down
k       scroll-up
/       search-forward
# ... one section per mode: viewing, search, filter, goto-line,
#     colon-command, mark, jump-to-mark, input

[input]
ctrl-a  cursor-home
ctrl-e  cursor-end
ctrl-k  delete-to-end
```

By default the file is **overlaid on top of the defaults**: only the keys you
list change, everything else stays as-is. Add `!clear` at the top to start
from a blank slate instead.

### Error handling

| How the file was found | Parse error | Unknown key/action |
|---|---|---|
| `--keybindings` (explicit) | Fatal error before startup | Fatal error |
| Default path | Warning to stderr, continue with partial bindings | Warning to stderr |

### Implementation notes

- All per-mode `switch key / switch char` blocks are replaced by a
  table-driven dispatch through `ModeBindings`, with common scroll/quit/edit
  actions factored into a single `executeCommonAction` method on `*Pager`.

### What doesn't change

Default key bindings are identical to before. Users who don't create a config
file see no difference in behavior.


### Related issues

- Fixes https://github.com/walles/moor/issues/107
- Fixes https://github.com/walles/moor/issues/419
- Addresses https://github.com/walles/moor/issues/334
