### PR TITLE
Reset scroll position when switching files

### DIFF
--- a/internal/file-switching.go
+++ b/internal/file-switching.go
@@ -12,7 +12,7 @@ func (p *Pager) previousFile() {
 	if newIndex < 0 {
 		newIndex = 0
 	}
-	p.currentReader = newIndex
+	p.switchToFile(newIndex)
 	log.Tracef("Switched to previous file, index %d", p.currentReader)
 
 	select {
@@ -29,7 +29,7 @@ func (p *Pager) nextFile() {
 	if newIndex >= len(p.readers) {
 		newIndex = len(p.readers) - 1
 	}
-	p.currentReader = newIndex
+	p.switchToFile(newIndex)
 	log.Tracef("Switched to next file, index %d", p.currentReader)
 
 	select {
@@ -42,11 +42,20 @@ func (p *Pager) firstFile() {
 	p.readerLock.Lock()
 	defer p.readerLock.Unlock()
 
-	p.currentReader = 0
+	p.switchToFile(0)
 	log.Tracef("Switched to first file, index %d", p.currentReader)
 
 	select {
 	case p.readerSwitched <- struct{}{}:
 	default:
 	}
+}
+
+func (p *Pager) switchToFile(newIndex int) {
+	if newIndex == p.currentReader {
+		return
+	}
+
+	p.currentReader = newIndex
+	p.scrollPosition = newScrollPosition("Pager file switch")
 }

--- a/internal/file-switching_test.go
+++ b/internal/file-switching_test.go
@@ -1,0 +1,30 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/walles/moor/v2/internal/reader"
+	"github.com/walles/moor/v2/twin"
+	"gotest.tools/v3/assert"
+)
+
+func TestSwitchingToSmallerFileResetsScrollPosition(t *testing.T) {
+	largeReader := reader.NewFromTextForTesting("large", strings.Repeat("large\n", 100))
+	smallReader := reader.NewFromTextForTesting("small", "small\nfile")
+
+	pager := NewPager(largeReader, smallReader)
+	pager.screen = twin.NewFakeScreen(80, 10)
+	pager.ShowLineNumbers = false
+	pager.showLineNumbers = false
+
+	pager.scrollToEnd()
+	assert.Assert(t, pager.lineIndex().Index() > 0)
+
+	pager.nextFile()
+	pager.filteringReader.SetBackingReader(pager.readers[pager.currentReader])
+
+	rendered := pager.renderLines()
+	assert.Equal(t, renderedToString(rendered.lines[0].cells), "small")
+	assert.Equal(t, pager.lineIndex().Index(), 0)
+}


### PR DESCRIPTION
Fixes #426.

## Summary

- Reset the pager scroll position when switching to another file via `:n`, `:p`, or `:x`.
- Added a regression test for switching from a large file scrolled near the end to a smaller file.

## Root Cause

File switching updated the active reader index, but kept the previous file scroll position. When the next file had fewer lines, rendering could still try to resolve a viewport based on the previous file and panic while looking for a line index that was no longer present in the rendered window.

## Validation

- `go test ./internal -run 'TestSwitchingToSmallerFileResetsScrollPosition|TestShortenedInput|TestIssue415Panic'`\n- `go test ./...`