### PR TITLE
Reset scroll position when switching files

### DIFF
--- a/internal/file-switching.go
+++ b/internal/file-switching.go
@@ -12,7 +12,7 @@ func (p *Pager) previousFile() {
 	if newIndex < 0 {
 		newIndex = 0
 	}
-	p.currentReader = newIndex
+	p.switchToFile(newIndex)
 	log.Tracef("Switched to previous file, index %d", p.currentReader)
 
 	select {
@@ -29,7 +29,7 @@ func (p *Pager) nextFile() {
 	if newIndex >= len(p.readers) {
 		newIndex = len(p.readers) - 1
 	}
-	p.currentReader = newIndex
+	p.switchToFile(newIndex)
 	log.Tracef("Switched to next file, index %d", p.currentReader)
 
 	select {
@@ -42,11 +42,20 @@ func (p *Pager) firstFile() {
 	p.readerLock.Lock()
 	defer p.readerLock.Unlock()
 
-	p.currentReader = 0
+	p.switchToFile(0)
 	log.Tracef("Switched to first file, index %d", p.currentReader)
 
 	select {
 	case p.readerSwitched <- struct{}{}:
 	default:
 	}
+}
+
+func (p *Pager) switchToFile(newIndex int) {
+	if newIndex == p.currentReader {
+		return
+	}
+
+	p.currentReader = newIndex
+	p.scrollPosition = newScrollPosition("Pager file switch")
 }

--- a/internal/file-switching_test.go
+++ b/internal/file-switching_test.go
@@ -1,0 +1,45 @@
+package internal
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/walles/moor/v2/internal/linemetadata"
+	"github.com/walles/moor/v2/internal/reader"
+	"github.com/walles/moor/v2/twin"
+	"gotest.tools/v3/assert"
+)
+
+func TestIssue426SwitchingToSmallerFileClearsStaleScrollPosition(t *testing.T) {
+	largeReader := reader.NewFromTextForTesting("large", strings.Repeat("large\n", 118))
+	smallReader := reader.NewFromTextForTesting("small", strings.Repeat("small\n", 48))
+	assert.NilError(t, largeReader.Wait())
+	assert.NilError(t, smallReader.Wait())
+
+	pager := NewPager(largeReader, smallReader)
+	pager.screen = twin.NewFakeScreen(190, 49)
+	pager.WrapLongLines = true
+	pager.ShowLineNumbers = false
+	pager.showLineNumbers = false
+	pager.filteringReader.SetBackingReader(smallReader)
+
+	// This matches the stale post-switch state from issue #426: the reader has
+	// moved to a shorter file, but the scroll position still points below it.
+	staleIndex := linemetadata.IndexFromZeroBased(70)
+	staleIndexPtr := &staleIndex
+	pager.scrollPosition = scrollPosition{
+		internalDontTouch: scrollPositionInternal{
+			lineIndex: staleIndexPtr,
+			delta:     0,
+			name:      "Issue 426 stale file switch",
+		},
+	}
+	pager.scrollPosition.internalDontTouch.canonical = canonicalFromPager(pager)
+
+	pager.nextFile()
+
+	rendered := pager.renderLines()
+	assert.Assert(t, len(rendered.lines) > 0)
+	assert.Equal(t, renderedToString(rendered.lines[0].cells), "small")
+	assert.Equal(t, pager.lineIndex().Index(), 0)
+}


### PR DESCRIPTION
Fixes #426.

## Summary

- Reset the pager scroll position when switching to another file via `:n`, `:p`, or `:x`.
- Replaced the earlier weak test with a regression test that reproduces the stale post-switch scroll state from #426.

## Root Cause

File switching updated the active reader index, but kept the previous file scroll position. When the next file had fewer lines, rendering could still try to resolve a viewport based on the previous file and panic while looking for a line index that was no longer present in the rendered window.

The reporter later posted a full v2.13.3 trace in #426. It matches this path: the panic happens from `internalRenderLines()` immediately after `Switched to next file`, with a saved scroll position that no longer exists for the new file.

## Validation

- Applied only the new `TestIssue426SwitchingToSmallerFileClearsStaleScrollPosition` test to `origin/master`: it fails with `panic: scrollPosition index={70} not found in allLines size 48, indexed {0}-{47}`.
- `go test ./internal -run 'TestIssue426SwitchingToSmallerFileClearsStaleScrollPosition|TestShortenedInput|TestIssue415Panic|TestIssue399' -count=1`
- `go test ./...`