### PR TITLE
Add startup search option

### DIFF
--- a/cmd/moor/moor.go
+++ b/cmd/moor/moor.go
@@ -433,6 +433,7 @@ func pagerFromArgs(
 	reFormat := flagSet.Bool("reformat", false, "Reformat some input files (JSON)")
 	flagSet.Bool("no-reformat", true, "No effect, kept for compatibility. See --reformat")
 	quitIfOneScreen := flagSet.Bool("quit-if-one-screen", false, "Don't page if contents fits on one screen. Affected by --no-clear-on-exit-margin.")
+	initialSearch := flagSet.String("search", "", "Search for `pattern` on startup")
 	noClearOnExit := flagSet.Bool("no-clear-on-exit", false, "Retain screen contents when exiting moor")
 	noClearOnExitMargin := flagSet.Int("no-clear-on-exit-margin", 1,
 		"Number of lines to leave for your shell prompt, defaults to 1")
@@ -645,6 +646,7 @@ func pagerFromArgs(
 	pager.DeInit = !*noClearOnExit
 	pager.DeInitFalseMargin = *noClearOnExitMargin
 	pager.QuitIfOneScreen = *quitIfOneScreen
+	pager.InitialSearch = *initialSearch
 	pager.StatusBarStyle = *statusBarStyle
 	pager.UnprintableStyle = *unprintableStyle
 	pager.WithTerminalFg = *terminalFg

--- a/cmd/moor/moor_test.go
+++ b/cmd/moor/moor_test.go
@@ -45,6 +45,21 @@ func TestPageOneInputFile(t *testing.T) {
 	assert.Assert(t, formatter != nil)
 }
 
+func TestSearchOption(t *testing.T) {
+	pager, _, _, _, _, err := pagerFromArgs(
+		[]string{"", "--search", "func TestSearchOption", "moor_test.go"},
+		func(_ twin.MouseMode, _ twin.ColorCount) (twin.Screen, error) {
+			return twin.NewFakeScreen(80, 24), nil
+		},
+		false, // stdin is redirected
+		false, // stdout is redirected
+	)
+
+	assert.NilError(t, err)
+	assert.Assert(t, pager != nil)
+	assert.Equal(t, pager.InitialSearch, "func TestSearchOption")
+}
+
 func TestGetTargetLine(t *testing.T) {
 	index, remaining := getTargetLine([]string{})
 	assert.Assert(t, index == nil)

--- a/internal/pager-search_test.go
+++ b/internal/pager-search_test.go
@@ -190,6 +190,23 @@ func Test152(t *testing.T) {
 	assert.Equal(t, 2, pager.lineIndex().Index())
 }
 
+func TestInitialSearch(t *testing.T) {
+	reader := reader.NewFromTextForTesting("", "alpha\nneedle\nomega\n")
+	screen := twin.NewFakeScreen(20, 5)
+	pager := NewPager(reader)
+	pager.InitialSearch = "needle"
+	pager.ShowLineNumbers = false
+	pager.showLineNumbers = false
+
+	pager.Quit()
+	pager.StartPaging(screen, nil, nil)
+	pager.redraw("")
+
+	assert.Equal(t, pager.search.String(), "needle")
+	assert.Equal(t, true, pager.searchHitIsVisible())
+	assert.Equal(t, "Viewing", modeName(pager))
+}
+
 func TestScrollLeftToSearchHits_NoLineNumbers(t *testing.T) {
 	reader := reader.NewFromTextForTesting("", "a234567890")
 	screen := twin.NewFakeScreen(10, 5)

--- a/internal/pager.go
+++ b/internal/pager.go
@@ -98,6 +98,9 @@ type Pager struct {
 	// Ref: https://github.com/walles/moor/issues/113
 	QuitIfOneScreen bool
 
+	// Search for this string on startup.
+	InitialSearch string
+
 	// Ref: https://github.com/walles/moor/issues/94
 	ScrollLeftHint  textstyles.CellWithMetadata
 	ScrollRightHint textstyles.CellWithMetadata
@@ -546,6 +549,14 @@ func (p *Pager) StartPaging(screen twin.Screen, chromaStyle *chroma.Style, chrom
 
 	// Make sure the reader knows how many lines we want
 	p.setTargetLine(p.TargetLine)
+	if p.InitialSearch != "" {
+		p.search.For(p.InitialSearch)
+		p.searchHistory.addEntry(p.InitialSearch)
+
+		reallyHigh := linemetadata.IndexMax()
+		p.setTargetLine(&reallyHigh)
+		p.scrollToSearchHits()
+	}
 
 	go func() {
 		defer func() {

--- a/moor.1
+++ b/moor.1
@@ -108,6 +108,9 @@ in caps will be interpreted as one escape character.
 Example value for faint (using ANSI SGR code 2) tilde characters:
 .B ESC[2m~
 .TP
+\fB\-\-search\fR=string
+Search for this string on startup. Once started, use \fBn\fR and \fBp\fR to jump between matches.
+.TP
 \fB\-\-shift\fR=int
 Arrow keys side scroll amount. Or try ALT+arrow to scroll one column at a time.
 .TP


### PR DESCRIPTION
Fixes #389

## Repro / motivation

`moor` already supports interactive search, but there was no CLI equivalent for tools such as `delta` to open a file with an initial search term ready for `n` / `p` navigation.

## Fix

Added `--search <pattern>`:

- parses the startup search term from CLI args
- applies it through the existing pager search state on startup
- jumps to the first visible match when possible
- leaves the pager in normal viewing mode so `n` and `p` work immediately
- documents the option in the man page

## Tests

- `go test ./cmd/moor ./internal -run 'TestSearchOption|TestInitialSearch|Test152|TestScrollToNextSearchHit'`
- `go test ./...`
- `./build.sh && MOOR_SKIP_INTERACTIVE_TESTS=1 ./test.sh`