### PR TITLE
use shebang to pick lexer for scripts without filename extension

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/alecthomas/chroma/v2 v2.22.0
 	github.com/charlievieth/strcase v0.0.5
 	github.com/davecgh/go-spew v1.1.1
+	github.com/go-enry/go-enry/v2 v2.9.6
 	github.com/google/go-cmp v0.5.9
 	github.com/klauspost/compress v1.17.4
 	github.com/rivo/uniseg v0.4.7
@@ -17,6 +18,8 @@ require (
 	golang.org/x/term v0.0.0-20210503060354-a79de5458b56
 	gotest.tools/v3 v3.3.0
 )
+
+require github.com/go-enry/go-oniguruma v1.2.1 // indirect
 
 require (
 	github.com/dlclark/regexp2 v1.11.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/go-enry/go-enry/v2 v2.9.6 h1:np63eOtMV56zfYDHnFVgpEVOk8fr2kmylcMnAZUDbSs=
+github.com/go-enry/go-enry/v2 v2.9.6/go.mod h1:9yrj4ES1YrbNb1Wb7/PWYr2bpaCXUGRt0uafN0ISyG8=
+github.com/go-enry/go-oniguruma v1.2.1 h1:k8aAMuJfMrqm/56SG2lV9Cfti6tC4x8673aHCcBk+eo=
+github.com/go-enry/go-oniguruma v1.2.1/go.mod h1:bWDhYP+S6xZQgiRL7wlTScFYBe023B6ilRZbCAD5Hf4=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -28,7 +32,12 @@ github.com/sirupsen/logrus v1.8.3 h1:DBBfY8eMYazKEJHb3JKpSPfpgd2mBCoNFlQx6C5fftU
 github.com/sirupsen/logrus v1.8.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
@@ -66,6 +75,7 @@ golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/reader/constructors.go
+++ b/internal/reader/constructors.go
@@ -3,7 +3,6 @@ package reader
 // This file contains factory functions for creating Readers from various inputs.
 
 import (
-	"bytes"
 	"io"
 	"os"
 	"path/filepath"
@@ -13,7 +12,6 @@ import (
 
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/lexers"
-	"github.com/go-enry/go-enry/v2"
 )
 
 // NewFromFilename creates a new file reader.
@@ -44,23 +42,6 @@ func NewFromFilename(filename string, formatter chroma.Formatter, options Reader
 
 	if options.Lexer == nil {
 		options.Lexer = lexers.Match(highlightingFilename)
-	}
-	if options.Lexer == nil {
-		if seekable, ok := stream.(io.ReadSeeker); ok {
-			p := make([]byte, 1000)
-			n, err := seekable.Read(p)
-			_, _ = seekable.Seek(0, io.SeekStart)
-			if err == nil {
-				p = p[:n]
-				language := enry.GetLanguage(highlightingFilename, p)
-				if language == "" && bytes.HasPrefix(p, []byte("%!PS")) {
-					language = "postscript"
-				}
-				if language != "" {
-					options.Lexer = lexers.Get(language)
-				}
-			}
-		}
 	}
 
 	returnMe := newReaderFromStream(stream, &filename, formatter, options)

--- a/internal/reader/constructors.go
+++ b/internal/reader/constructors.go
@@ -65,6 +65,8 @@ func NewFromFilename(filename string, formatter chroma.Formatter, options Reader
 					} else if strings.HasPrefix(s, "wish") {
 						// wish is the interpreter for Tk, which has the same syntax as Tcl
 						s = "tcl"
+					} else if strings.HasPrefix(s, "deno") || strings.HasPrefix(s, "node") {
+						s = "javascript"
 					}
 					options.Lexer = lexers.Get(s)
 				}

--- a/internal/reader/constructors.go
+++ b/internal/reader/constructors.go
@@ -3,20 +3,17 @@ package reader
 // This file contains factory functions for creating Readers from various inputs.
 
 import (
+	"bytes"
 	"io"
 	"os"
 	"path/filepath"
-	"regexp"
 	"runtime/debug"
 	"strings"
 	"sync/atomic"
 
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/lexers"
-)
-
-var (
-	reShebang = regexp.MustCompile(`\A#!\S*/(?:env[ \t]+)?(\S+)`)
+	"github.com/go-enry/go-enry/v2"
 )
 
 // NewFromFilename creates a new file reader.
@@ -50,25 +47,17 @@ func NewFromFilename(filename string, formatter chroma.Formatter, options Reader
 	}
 	if options.Lexer == nil {
 		if seekable, ok := stream.(io.ReadSeeker); ok {
-			p := make([]byte, 256)
-			_, err := seekable.Read(p)
+			p := make([]byte, 1000)
+			n, err := seekable.Read(p)
 			_, _ = seekable.Seek(0, io.SeekStart)
 			if err == nil {
-				m := reShebang.FindSubmatch(p)
-				if m != nil {
-					s := string(m[1])
-					if strings.HasPrefix(s, "python2") {
-						// Lexer knows about python2 and python3, but not about python2.x
-						s = "python2"
-					} else if strings.HasPrefix(s, "python3") {
-						s = "python3"
-					} else if strings.HasPrefix(s, "wish") {
-						// wish is the interpreter for Tk, which has the same syntax as Tcl
-						s = "tcl"
-					} else if strings.HasPrefix(s, "deno") || strings.HasPrefix(s, "node") {
-						s = "javascript"
-					}
-					options.Lexer = lexers.Get(s)
+				p = p[:n]
+				language := enry.GetLanguage(highlightingFilename, p)
+				if language == "" && bytes.HasPrefix(p, []byte("%!PS")) {
+					language = "postscript"
+				}
+				if language != "" {
+					options.Lexer = lexers.Get(language)
 				}
 			}
 		}

--- a/internal/reader/constructors.go
+++ b/internal/reader/constructors.go
@@ -52,7 +52,7 @@ func NewFromFilename(filename string, formatter chroma.Formatter, options Reader
 		if seekable, ok := stream.(io.ReadSeeker); ok {
 			p := make([]byte, 256)
 			_, err := seekable.Read(p)
-			seekable.Seek(0, io.SeekStart)
+			_, _ = seekable.Seek(0, io.SeekStart)
 			if err == nil {
 				m := reShebang.FindSubmatch(p)
 				if m != nil {

--- a/internal/reader/constructors.go
+++ b/internal/reader/constructors.go
@@ -6,12 +6,17 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime/debug"
 	"strings"
 	"sync/atomic"
 
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/lexers"
+)
+
+var (
+	reShebang = regexp.MustCompile(`\A#!\S*/(?:env[ \t]+)?(\S+)`)
 )
 
 // NewFromFilename creates a new file reader.
@@ -42,6 +47,29 @@ func NewFromFilename(filename string, formatter chroma.Formatter, options Reader
 
 	if options.Lexer == nil {
 		options.Lexer = lexers.Match(highlightingFilename)
+	}
+	if options.Lexer == nil {
+		if seekable, ok := stream.(io.ReadSeeker); ok {
+			p := make([]byte, 256)
+			_, err := seekable.Read(p)
+			seekable.Seek(0, io.SeekStart)
+			if err == nil {
+				m := reShebang.FindSubmatch(p)
+				if m != nil {
+					s := string(m[1])
+					if strings.HasPrefix(s, "python2") {
+						// Lexer knows about python2 and python3, but not about python2.x
+						s = "python2"
+					} else if strings.HasPrefix(s, "python3") {
+						s = "python3"
+					} else if strings.HasPrefix(s, "wish") {
+						// wish is the interpreter for Tk, which has the same syntax as Tcl
+						s = "tcl"
+					}
+					options.Lexer = lexers.Get(s)
+				}
+			}
+		}
 	}
 
 	returnMe := newReaderFromStream(stream, &filename, formatter, options)

--- a/internal/reader/highlight.go
+++ b/internal/reader/highlight.go
@@ -91,9 +91,6 @@ func highlightFromMemory(reader *ReaderImpl, formatter chroma.Formatter, options
 		// The Chroma JSON lexer natively supports JSONL as well:
 		// https://github.com/alecthomas/chroma/pull/1262
 		options.Lexer = lexers.Get("json")
-	} else if options.Lexer == nil && isPostScript(text) {
-		log.Info("Buffer has PostScript marker, highlighting as PostScript")
-		options.Lexer = lexers.Get("postscript")
 	}
 
 	if options.Lexer == nil {
@@ -164,10 +161,6 @@ func textAsString(reader *ReaderImpl, shouldFormat bool) string {
 
 	log.Debug("Got the --reformat flag, reformatted JSON input")
 	return string(prettyJSON)
-}
-
-func isPostScript(text string) bool {
-	return strings.HasPrefix(text, "%!PS")
 }
 
 func isJsonOrJsonl(text string) bool {

--- a/internal/reader/highlight.go
+++ b/internal/reader/highlight.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alecthomas/chroma/v2"
 	"github.com/alecthomas/chroma/v2/lexers"
+	"github.com/go-enry/go-enry/v2"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -94,6 +95,17 @@ func highlightFromMemory(reader *ReaderImpl, formatter chroma.Formatter, options
 	} else if options.Lexer == nil && isXml(text) {
 		log.Info("Buffer is valid XML, highlighting as XML")
 		options.Lexer = lexers.Get("xml")
+	} else if options.Lexer == nil && isPostScript(text) {
+		log.Info("Buffer has PostScript marker, highlighting as PostScript")
+		options.Lexer = lexers.Get("postscript")
+	}
+
+	if options.Lexer == nil {
+		language := enry.GetLanguage("", []byte(text))
+		if language != "" {
+			log.Info("Buffer language detected as " + language)
+			options.Lexer = lexers.Get(language)
+		}
 	}
 
 	if options.Lexer == nil {
@@ -161,6 +173,10 @@ func textAsString(reader *ReaderImpl, shouldFormat bool) string {
 func isXml(text string) bool {
 	err := xml.Unmarshal([]byte(text), new(any))
 	return err == nil
+}
+
+func isPostScript(text string) bool {
+	return strings.HasPrefix(text, "%!PS")
 }
 
 func isJsonOrJsonl(text string) bool {

--- a/internal/reader/highlight.go
+++ b/internal/reader/highlight.go
@@ -3,7 +3,6 @@ package reader
 import (
 	"bytes"
 	"encoding/json"
-	"encoding/xml"
 	"strings"
 
 	"github.com/alecthomas/chroma/v2"
@@ -92,9 +91,6 @@ func highlightFromMemory(reader *ReaderImpl, formatter chroma.Formatter, options
 		// The Chroma JSON lexer natively supports JSONL as well:
 		// https://github.com/alecthomas/chroma/pull/1262
 		options.Lexer = lexers.Get("json")
-	} else if options.Lexer == nil && isXml(text) {
-		log.Info("Buffer is valid XML, highlighting as XML")
-		options.Lexer = lexers.Get("xml")
 	} else if options.Lexer == nil && isPostScript(text) {
 		log.Info("Buffer has PostScript marker, highlighting as PostScript")
 		options.Lexer = lexers.Get("postscript")
@@ -168,11 +164,6 @@ func textAsString(reader *ReaderImpl, shouldFormat bool) string {
 
 	log.Debug("Got the --reformat flag, reformatted JSON input")
 	return string(prettyJSON)
-}
-
-func isXml(text string) bool {
-	err := xml.Unmarshal([]byte(text), new(any))
-	return err == nil
 }
 
 func isPostScript(text string) bool {


### PR DESCRIPTION
**This is a work in progress.** By creating this pull request, I'm hoping to get feedback to help me finish it.

The goal is to pick the right lexer when it can't be determined from the filename extension, by using the shebang, the first line of the script that sets the interpreter. For example:

```
#!/usr/bin/env python
```

It only works for files that are opened by `moor`, not file contents read from standard input. For the latter case, processing the shebang should be done when the input is actually read, but I could not figure out (yet) when/how this happens.

There is another issue with this code. The lexer code doesn't know about interpreter names that are different from the language name. I fixed this for these cases:

- python2.*  ->  python2
- python3.*  ->  python3
- wish*      ->  tcl
- deno       ->  javascript
- node       ->  javascript

There could be more, but these are all I know about.

### file type from content

I am wondering if it's worth trying to do more file type recognition.

There are more ways to get the file type from the content, based on the first line:

- `<html>`  -> html (or could be php, is that a different lexer type?)
- `<?xml`   -> xml
- `%!PS`    -> postscript

And then scripts and, more general, other text files can contain a comment that tells an editor the type of content. Unfortunately, this is not standardised. Here is an example for `vim`:

```
# vim: set ft=sh:
```

And for Emacs:

```
# -*- mode: sh -*-
```
Further more, these lines can be near the top, or near the bottom of the file.

