### PR TITLE
Defend against other processes resetting the terminal mode

### DIFF
--- a/twin/interruptablereader.go
+++ b/twin/interruptablereader.go
@@ -17,6 +17,10 @@ type interruptableReader struct {
 	interrupted atomic.Bool
 
 	pauseOrRead semaphore.Weighted
+
+	// Re-apply the terminal mode we need. Replaced in tests, which have no
+	// terminal to observe; production code always wants reassertTtyInMode.
+	reassert func(ttyIn *os.File)
 }
 
 // Basically how long we wait between interrupt checks
@@ -28,6 +32,8 @@ func newInterruptableReader(base *os.File) interruptableReader {
 
 		// Ensures we can either read or be paused, but not both at the same time
 		pauseOrRead: *semaphore.NewWeighted(1),
+
+		reassert: reassertTtyInMode,
 	}
 }
 
@@ -74,7 +80,7 @@ func (r *interruptableReader) Read(p []byte) (n int, err error) {
 		//   - https://github.com/walles/moor/issues/443
 		//   - https://github.com/walles/moor/issues/394
 		if r.pauseOrRead.TryAcquire(1) {
-			reassertTtyInMode(r.base)
+			r.reassert(r.base)
 			r.pauseOrRead.Release(1)
 		}
 

--- a/twin/interruptablereader.go
+++ b/twin/interruptablereader.go
@@ -64,8 +64,7 @@ func (r *interruptableReader) Read(p []byte) (n int, err error) {
 
 		// Other processes can (and do) reset the terminal mode behind our back.
 		// We cannot detect that happening, so we just keep re-applying the mode
-		// we need here, since this loop runs at least once every
-		// interruptableReaderMaxWait.
+		// we need.
 		//
 		// This must happen even when there is nothing to read: in cooked mode
 		// keystrokes are line buffered by the kernel, so they don't make our fd
@@ -84,11 +83,9 @@ func (r *interruptableReader) Read(p []byte) (n int, err error) {
 			r.pauseOrRead.Release(1)
 		}
 
-		// If the terminal mode gets reset while we're waiting here, the
-		// re-assert at the top of the next iteration will sort it out. Any
-		// keystrokes made in the meantime will be line buffered by the kernel,
-		// and become readable once we're back in raw mode during the next
-		// iteration.
+		// A reset while we're waiting here is fine: the wait is bounded, and
+		// the next re-assert picks it up. Keystrokes made in the meantime stay
+		// buffered by the kernel until then.
 		ready, waitErr := r.waitForReadReady(interruptableReaderMaxWait)
 		if waitErr != nil {
 			return 0, waitErr
@@ -107,6 +104,14 @@ func (r *interruptableReader) Read(p []byte) (n int, err error) {
 		if err != nil {
 			panic(fmt.Errorf("Failed to acquire interruptable reader pause semaphore for reading: %w", err))
 		}
+
+		// The acquire above can have waited out a whole pause, with every
+		// re-assert at the top of the loop skipped throughout it. Re-assert
+		// here, because the read below blocks while holding the semaphore: if
+		// the mode is wrong by then, the top of the loop won't get to fix it
+		// either.
+		r.reassert(r.base)
+
 		n, err = r.base.Read(p)
 		r.pauseOrRead.Release(1)
 

--- a/twin/interruptablereader.go
+++ b/twin/interruptablereader.go
@@ -56,6 +56,33 @@ func (r *interruptableReader) Read(p []byte) (n int, err error) {
 			return 0, io.EOF
 		}
 
+		// Other processes can (and do) reset the terminal mode behind our back.
+		// We cannot detect that happening, so we just keep re-applying the mode
+		// we need here, since this loop runs at least once every
+		// interruptableReaderMaxWait.
+		//
+		// This must happen even when there is nothing to read: in cooked mode
+		// keystrokes are line buffered by the kernel, so they don't make our fd
+		// readable until the user presses enter. Waiting with the re-assert
+		// until we have something to read would be waiting for input that
+		// cannot arrive.
+		//
+		// The semaphore makes sure we never re-assert while the terminal mode
+		// has intentionally been restored, by PauseAndCall() or by Close().
+		//
+		// Refs:
+		//   - https://github.com/walles/moor/issues/443
+		//   - https://github.com/walles/moor/issues/394
+		if r.pauseOrRead.TryAcquire(1) {
+			reassertTtyInMode(r.base)
+			r.pauseOrRead.Release(1)
+		}
+
+		// If the terminal mode gets reset while we're waiting here, the
+		// re-assert at the top of the next iteration will sort it out. Any
+		// keystrokes made in the meantime will be line buffered by the kernel,
+		// and become readable once we're back in raw mode during the next
+		// iteration.
 		ready, waitErr := r.waitForReadReady(interruptableReaderMaxWait)
 		if waitErr != nil {
 			return 0, waitErr

--- a/twin/screen-setup-windows.go
+++ b/twin/screen-setup-windows.go
@@ -14,6 +14,22 @@ import (
 	"golang.org/x/term"
 )
 
+// Console mode flags we need for paging to work. Applied in setupTtyInTtyOut()
+// and re-applied by reassertTtyInMode() / reassertTtyOutMode().
+//
+// Set and clear flags rather than one absolute mode, because flags not listed
+// here must be left alone. Some are user preferences (ENABLE_QUICK_EDIT_MODE),
+// and the console flips ENABLE_MOUSE_INPUT by itself when we enable mouse
+// tracking, so writing an absolute mode would turn mouse reporting back off.
+const (
+	ttyInSetFlags = windows.ENABLE_VIRTUAL_TERMINAL_INPUT
+
+	// These match what term.MakeRaw() clears on Windows
+	ttyInClearFlags = windows.ENABLE_ECHO_INPUT | windows.ENABLE_LINE_INPUT | windows.ENABLE_PROCESSED_INPUT
+
+	ttyOutSetFlags = windows.ENABLE_PROCESSED_OUTPUT | windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING
+)
+
 var peekNamedPipe = windows.NewLazySystemDLL("kernel32.dll").NewProc("PeekNamedPipe")
 
 func waitForPipeReadReady(handle windows.Handle) (ready bool, err error) {
@@ -47,6 +63,48 @@ func waitForPipeReadReady(handle windows.Handle) (ready bool, err error) {
 	return false, fmt.Errorf("PeekNamedPipe failed: %w", callErr)
 }
 
+// cmd.exe resets the console modes behind our back, both while running batch
+// files and when the process piping into moor terminates. We cannot detect
+// when that happens, so instead we re-apply the flags we need before every
+// tty read and write, leaving all other flags untouched.
+//
+// less does the same thing.
+//
+// Ref: https://github.com/walles/moor/issues/394
+func reassertConsoleMode(handle windows.Handle, setFlags uint32, clearFlags uint32) {
+	var currentMode uint32
+	err := windows.GetConsoleMode(handle, &currentMode)
+	if err != nil {
+		// Not a console, nothing to re-assert
+		return
+	}
+
+	wantedMode := (currentMode | setFlags) &^ clearFlags
+	if wantedMode == currentMode {
+		return
+	}
+
+	err = windows.SetConsoleMode(handle, wantedMode)
+	if err != nil {
+		log.Debug(fmt.Sprintf("Failed to change console mode from %#x to %#x: %v", currentMode, wantedMode, err))
+		return
+	}
+
+	log.Debug(fmt.Sprintf("Console mode changed behind our back, set it back from %#x to %#x", currentMode, wantedMode))
+}
+
+// Re-apply the ttyIn console mode set by setupTtyInTtyOut(), in case cmd.exe
+// has reset it.
+func reassertTtyInMode(ttyIn *os.File) {
+	reassertConsoleMode(windows.Handle(ttyIn.Fd()), ttyInSetFlags, ttyInClearFlags)
+}
+
+// Re-apply the ttyOut console mode set by setupTtyInTtyOut(), in case cmd.exe
+// has reset it.
+func reassertTtyOutMode(ttyOut *os.File) {
+	reassertConsoleMode(windows.Handle(ttyOut.Fd()), ttyOutSetFlags, 0)
+}
+
 func (r *interruptableReader) waitForReadReady(timeout time.Duration) (ready bool, err error) {
 	fileType, err := windows.GetFileType(windows.Handle(r.base.Fd()))
 	if err != nil {
@@ -68,6 +126,9 @@ func (r *interruptableReader) waitForReadReady(timeout time.Duration) (ready boo
 		time.Sleep(timeout / 2)
 		return
 	}
+
+	// We're reading from the console
+	reassertTtyInMode(r.base)
 
 	timeoutMillis := uint32(timeout.Milliseconds())
 	if timeoutMillis == 0 {
@@ -137,15 +198,9 @@ func (screen *UnixScreen) setupTtyInTtyOut() error {
 	if err != nil {
 		return fmt.Errorf("failed to get stdin console mode: %w", err)
 	}
-	err = windows.SetConsoleMode(stdin, screen.oldTtyInMode|windows.ENABLE_VIRTUAL_TERMINAL_INPUT)
+	err = windows.SetConsoleMode(stdin, (screen.oldTtyInMode|ttyInSetFlags)&^ttyInClearFlags)
 	if err != nil {
 		return fmt.Errorf("failed to set stdin console mode: %w", err)
-	}
-
-	screen.oldTerminalState, err = term.MakeRaw(int(screen.ttyIn.Fd()))
-	if err != nil {
-		screen.restoreTtyInTtyOut() // Error intentionally ignored, report the first one only
-		return fmt.Errorf("failed to set raw mode: %w", err)
 	}
 
 	screen.ttyOut = os.Stdout
@@ -157,7 +212,7 @@ func (screen *UnixScreen) setupTtyInTtyOut() error {
 		screen.restoreTtyInTtyOut() // Error intentionally ignored, report the first one only
 		return fmt.Errorf("failed to get stdout console mode: %w", err)
 	}
-	err = windows.SetConsoleMode(stdout, screen.oldTtyOutMode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING)
+	err = windows.SetConsoleMode(stdout, screen.oldTtyOutMode|ttyOutSetFlags)
 	if err != nil {
 		screen.restoreTtyInTtyOut() // Error intentionally ignored, report the first one only
 		return fmt.Errorf("failed to set stdout console mode: %w", err)

--- a/twin/screen-setup-windows.go
+++ b/twin/screen-setup-windows.go
@@ -66,11 +66,11 @@ func waitForPipeReadReady(handle windows.Handle) (ready bool, err error) {
 // Make sure the given console mode flags are set / cleared, leaving all other
 // flags untouched.
 //
-// Called both at setup and before every tty read and write. The repetition is
-// needed because cmd.exe resets the console modes behind our back, both while
-// running batch files and when the process piping into moor terminates. We
-// cannot detect when that happens, so we just keep re-applying the flags we
-// need.
+// Called at setup, from the interruptableReader.Read() loop, and before every
+// tty write. The repetition is needed because cmd.exe resets the console modes
+// behind our back, both while running batch files and when the process piping
+// into moor terminates. We cannot detect when that happens, so we just keep
+// re-applying the flags we need.
 //
 // less does the same thing.
 //
@@ -136,9 +136,6 @@ func (r *interruptableReader) waitForReadReady(timeout time.Duration) (ready boo
 		time.Sleep(timeout / 2)
 		return
 	}
-
-	// We're reading from the console
-	reassertTtyInMode(r.base)
 
 	timeoutMillis := uint32(timeout.Milliseconds())
 	if timeoutMillis == 0 {

--- a/twin/screen-setup-windows.go
+++ b/twin/screen-setup-windows.go
@@ -63,46 +63,56 @@ func waitForPipeReadReady(handle windows.Handle) (ready bool, err error) {
 	return false, fmt.Errorf("PeekNamedPipe failed: %w", callErr)
 }
 
-// cmd.exe resets the console modes behind our back, both while running batch
-// files and when the process piping into moor terminates. We cannot detect
-// when that happens, so instead we re-apply the flags we need before every
-// tty read and write, leaving all other flags untouched.
+// Make sure the given console mode flags are set / cleared, leaving all other
+// flags untouched.
+//
+// Called both at setup and before every tty read and write. The repetition is
+// needed because cmd.exe resets the console modes behind our back, both while
+// running batch files and when the process piping into moor terminates. We
+// cannot detect when that happens, so we just keep re-applying the flags we
+// need.
 //
 // less does the same thing.
 //
 // Ref: https://github.com/walles/moor/issues/394
-func reassertConsoleMode(handle windows.Handle, setFlags uint32, clearFlags uint32) {
+func reassertConsoleMode(handle windows.Handle, setFlags uint32, clearFlags uint32) error {
 	var currentMode uint32
 	err := windows.GetConsoleMode(handle, &currentMode)
 	if err != nil {
 		// Not a console, nothing to re-assert
-		return
+		return nil
 	}
 
 	wantedMode := (currentMode | setFlags) &^ clearFlags
 	if wantedMode == currentMode {
-		return
+		return nil
 	}
 
 	err = windows.SetConsoleMode(handle, wantedMode)
 	if err != nil {
-		log.Debug(fmt.Sprintf("Failed to change console mode from %#x to %#x: %v", currentMode, wantedMode, err))
-		return
+		return fmt.Errorf("failed to change console mode from %#x to %#x: %w", currentMode, wantedMode, err)
 	}
 
-	log.Debug(fmt.Sprintf("Console mode changed behind our back, set it back from %#x to %#x", currentMode, wantedMode))
+	log.Debug(fmt.Sprintf("Console mode changed from %#x to %#x", currentMode, wantedMode))
+	return nil
 }
 
 // Re-apply the ttyIn console mode set by setupTtyInTtyOut(), in case cmd.exe
 // has reset it.
 func reassertTtyInMode(ttyIn *os.File) {
-	reassertConsoleMode(windows.Handle(ttyIn.Fd()), ttyInSetFlags, ttyInClearFlags)
+	err := reassertConsoleMode(windows.Handle(ttyIn.Fd()), ttyInSetFlags, ttyInClearFlags)
+	if err != nil {
+		log.Debug(fmt.Sprint("Re-asserting ttyIn console mode: ", err))
+	}
 }
 
 // Re-apply the ttyOut console mode set by setupTtyInTtyOut(), in case cmd.exe
 // has reset it.
 func reassertTtyOutMode(ttyOut *os.File) {
-	reassertConsoleMode(windows.Handle(ttyOut.Fd()), ttyOutSetFlags, 0)
+	err := reassertConsoleMode(windows.Handle(ttyOut.Fd()), ttyOutSetFlags, 0)
+	if err != nil {
+		log.Debug(fmt.Sprint("Re-asserting ttyOut console mode: ", err))
+	}
 }
 
 func (r *interruptableReader) waitForReadReady(timeout time.Duration) (ready bool, err error) {
@@ -198,7 +208,7 @@ func (screen *UnixScreen) setupTtyInTtyOut() error {
 	if err != nil {
 		return fmt.Errorf("failed to get stdin console mode: %w", err)
 	}
-	err = windows.SetConsoleMode(stdin, (screen.oldTtyInMode|ttyInSetFlags)&^ttyInClearFlags)
+	err = reassertConsoleMode(stdin, ttyInSetFlags, ttyInClearFlags)
 	if err != nil {
 		return fmt.Errorf("failed to set stdin console mode: %w", err)
 	}
@@ -212,7 +222,7 @@ func (screen *UnixScreen) setupTtyInTtyOut() error {
 		screen.restoreTtyInTtyOut() // Error intentionally ignored, report the first one only
 		return fmt.Errorf("failed to get stdout console mode: %w", err)
 	}
-	err = windows.SetConsoleMode(stdout, screen.oldTtyOutMode|ttyOutSetFlags)
+	err = reassertConsoleMode(stdout, ttyOutSetFlags, 0)
 	if err != nil {
 		screen.restoreTtyInTtyOut() // Error intentionally ignored, report the first one only
 		return fmt.Errorf("failed to set stdout console mode: %w", err)

--- a/twin/screen-setup-windows.go
+++ b/twin/screen-setup-windows.go
@@ -108,6 +108,12 @@ func reassertTtyInMode(ttyIn *os.File) {
 
 // Re-apply the ttyOut console mode set by setupTtyInTtyOut(), in case cmd.exe
 // has reset it.
+//
+// Note that this can run after Close() has restored the original console
+// modes: ReprintAfterExit() renders through writeLocked() to leave the last
+// screen visible in the terminal. That reprint needs our flags to render
+// correctly, so we knowingly leave them enabled on exit. Should be harmless,
+// they are enabled by default in modern terminals.
 func reassertTtyOutMode(ttyOut *os.File) {
 	err := reassertConsoleMode(windows.Handle(ttyOut.Fd()), ttyOutSetFlags, 0)
 	if err != nil {

--- a/twin/screen-setup.go
+++ b/twin/screen-setup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"reflect"
 	"runtime/debug"
 	"syscall"
 	"time"
@@ -14,10 +15,62 @@ import (
 	"golang.org/x/term"
 )
 
+// Re-apply the raw mode set by setupTtyInTtyOut(), in case some other process
+// has reset the terminal mode behind our back.
+//
+// Node.js does that: it snapshots the terminal mode on startup and restores it
+// on exit. In a "node ... | moor" pipeline, node usually snapshots cooked mode
+// before we go raw, and then puts the terminal back into cooked mode when it
+// exits.
+//
+// Ref: https://github.com/walles/moor/issues/443
+func reassertTtyInMode(ttyIn *os.File) {
+	fd := int(ttyIn.Fd())
+
+	before, err := term.GetState(fd)
+	if err != nil {
+		// Not a terminal, nothing to re-assert
+		return
+	}
+
+	// MakeRaw() reads the current mode and adjusts only the raw mode related
+	// flags, so unrelated settings are preserved and repeated calls are
+	// harmless.
+	_, err = term.MakeRaw(fd)
+	if err != nil {
+		log.Debug(fmt.Sprint("Re-asserting raw terminal mode: ", err))
+		return
+	}
+
+	after, err := term.GetState(fd)
+	if err != nil {
+		return
+	}
+
+	if !reflect.DeepEqual(before, after) {
+		log.Debug("Terminal mode was reset behind our back, raw mode re-asserted")
+	}
+}
+
 func reassertTtyOutMode(_ *os.File) {
 	// This block intentionally left blank.
 	//
-	// See the implementation in twin/screen-setup-windows.go for info.
+	// Escape sequence interpretation is done by the terminal emulator, not by
+	// the kernel's termios layer, so our writes work no matter what state the
+	// termios is in.
+	//
+	// In cooked mode our "\r\n" line endings render as "\r\r\n" (ONLCR), but
+	// the extra "\r" is invisible on screen. So there is nothing here worth
+	// fixing.
+	//
+	// Re-asserting the termios state here would even be harmful: unlike the
+	// reads, writes are not synchronized with the intentional cooked mode
+	// restores done by PauseAndCall() and Close(), so we could race with
+	// those and re-raw the terminal right after they restored it.
+	//
+	// On Windows, input and output console modes are separate, and escape
+	// sequence interpretation does depend on the output mode, see the
+	// implementation in twin/screen-setup-windows.go.
 }
 
 func (r *interruptableReader) waitForReadReady(timeout time.Duration) (ready bool, err error) {

--- a/twin/screen-setup.go
+++ b/twin/screen-setup.go
@@ -44,11 +44,12 @@ func reassertTtyInMode(ttyIn *os.File) {
 
 	after, err := term.GetState(fd)
 	if err != nil {
+		log.Debug(fmt.Sprint("Re-asserting raw terminal mode, reading state back: ", err))
 		return
 	}
 
 	if !reflect.DeepEqual(before, after) {
-		log.Debug("Terminal mode was reset behind our back, raw mode re-asserted")
+		log.Info("Terminal mode was reset behind our back, raw mode re-asserted")
 	}
 }
 

--- a/twin/screen-setup.go
+++ b/twin/screen-setup.go
@@ -14,6 +14,12 @@ import (
 	"golang.org/x/term"
 )
 
+func reassertTtyOutMode(_ *os.File) {
+	// This block intentionally left blank.
+	//
+	// See the implementation in twin/screen-setup-windows.go for info.
+}
+
 func (r *interruptableReader) waitForReadReady(timeout time.Duration) (ready bool, err error) {
 	// "This argument should be set to the highest-numbered file descriptor in
 	// any of the three sets, plus 1. The indicated file descriptors in each set

--- a/twin/screen.go
+++ b/twin/screen.go
@@ -234,6 +234,8 @@ func (screen *UnixScreen) Events() chan Event {
 //
 // You must hold renderLock when calling this method.
 func (screen *UnixScreen) writeLocked(s string) int {
+	reassertTtyOutMode(screen.ttyOut)
+
 	bytesWritten, err := screen.ttyOut.Write([]byte(s))
 	if err != nil {
 		panic(err)

--- a/twin/screen.go
+++ b/twin/screen.go
@@ -214,6 +214,10 @@ func (screen *UnixScreen) Close() {
 	// Tell our main loop to exit
 	screen.ttyInReader.Interrupt()
 
+	// Prevent the reader from re-asserting our terminal mode after we restore
+	// it below. The screen is going away, so we never unpause.
+	screen.ttyInReader.SetPaused(true)
+
 	screen.leaveAlternateScreenSession()
 
 	err := screen.restoreTtyInTtyOut()

--- a/twin/screen_test.go
+++ b/twin/screen_test.go
@@ -335,6 +335,48 @@ func TestInterruptableReader_blockedOnRead(t *testing.T) {
 	assert.Equal(t, n, 0)
 }
 
+// An idle reader must keep re-asserting the terminal mode.
+//
+// A reset that happens while nothing is readable would otherwise never be
+// noticed: in cooked mode the kernel line buffers keystrokes, so waiting for
+// something to read before re-asserting would be waiting for input that cannot
+// arrive.
+func TestInterruptableReader_reassertsModeWhileIdle(t *testing.T) {
+	// Make a pipe to read from, and never write anything to it
+	pipeReader, _, err := os.Pipe()
+	assert.NilError(t, err)
+
+	// Make an interruptable reader that counts its terminal mode re-asserts
+	testMe := newInterruptableReader(pipeReader)
+	var reasserts atomic.Int32
+	testMe.reassert = func(*os.File) {
+		reasserts.Add(1)
+	}
+
+	// Start a thread that reads from the pipe. With nothing to read it will
+	// just keep polling.
+	readDone := make(chan struct{})
+	go func() {
+		defer func() {
+			panicHandler("TestInterruptableReader_reassertsModeWhileIdle()", recover(), debug.Stack())
+		}()
+
+		buffer := make([]byte, 1)
+		_, _ = testMe.Read(buffer)
+		close(readDone)
+	}()
+
+	// Long enough for the reader to poll a few times
+	time.Sleep(3 * interruptableReaderMaxWait)
+
+	assert.Assert(t, reasserts.Load() > 1,
+		"Idle reader should have re-asserted the terminal mode repeatedly, did it %d times",
+		reasserts.Load())
+
+	testMe.Interrupt()
+	<-readDone
+}
+
 // Resuming from a pause must re-assert the terminal mode before the reader
 // blocks on its next read.
 //

--- a/twin/screen_test.go
+++ b/twin/screen_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -332,6 +333,66 @@ func TestInterruptableReader_blockedOnRead(t *testing.T) {
 	n, err = testMe.Read(buffer)
 	assert.Equal(t, err, io.EOF)
 	assert.Equal(t, n, 0)
+}
+
+// Resuming from a pause must re-assert the terminal mode before the reader
+// blocks on its next read.
+//
+// Whatever ran during the pause may have left the terminal in a mode of its
+// own choosing. A reader that blocks first and re-asserts afterwards can end
+// up waiting for input that the current mode will never deliver, and then the
+// re-assert never happens because the blocked read is holding the semaphore.
+func TestInterruptableReader_reassertsModeWhenResuming(t *testing.T) {
+	// Make a pipe to read from and write to
+	pipeReader, pipeWriter, err := os.Pipe()
+	assert.NilError(t, err)
+
+	// Make an interruptable reader that counts its terminal mode re-asserts
+	testMe := newInterruptableReader(pipeReader)
+	var reasserts atomic.Int32
+	testMe.reassert = func(*os.File) {
+		reasserts.Add(1)
+	}
+
+	// Give the reader something to read, so that it gets all the way to its
+	// blocking read rather than looping on "nothing available yet"
+	n, err := pipeWriter.Write([]byte{42})
+	assert.NilError(t, err)
+	assert.Equal(t, n, 1)
+
+	testMe.SetPaused(true)
+
+	// Start a thread that reads from the pipe
+	readDone := make(chan struct{})
+	go func() {
+		defer func() {
+			panicHandler("TestInterruptableReader_reassertsModeWhenResuming()", recover(), debug.Stack())
+		}()
+
+		buffer := make([]byte, 1)
+		_, _ = testMe.Read(buffer)
+		close(readDone)
+	}()
+
+	// Wait for the reader thread to reach the blocking acquire it does just
+	// before reading. That takes only as long as starting a goroutine: the pipe
+	// already has data, so the readiness check returns immediately rather than
+	// polling for interruptableReaderMaxWait.
+	//
+	// Sleeping too little would make this test pass without proving anything,
+	// since a reader still at the top of its loop re-asserts there instead.
+	// Measured: one millisecond is enough, so this is a hundredfold margin.
+	time.Sleep(100 * time.Millisecond)
+
+	// Only re-asserts made after resuming count
+	reasserts.Store(0)
+
+	testMe.SetPaused(false)
+
+	<-readDone
+
+	assert.Assert(t, reasserts.Load() > 0,
+		"Terminal mode should have been re-asserted when resuming from the pause")
 }
 
 func TestInterruptableReader_interruptFirstReadLater(t *testing.T) {


### PR DESCRIPTION
## Problem

Other processes sharing our terminal can reset its mode behind moor's back, making the keyboard unusable: keypresses get echoed and line buffered instead of reaching moor.

* On Windows, `cmd.exe` resets the console modes, both while running batch files and when the process piping into moor terminates (#394)
* On Unix, Node.js snapshots the terminal mode at startup and restores it on exit. In a `node ... | moor` pipeline, node usually snapshots cooked mode before moor goes raw, and then puts the terminal back into cooked mode when it exits (#443)

We cannot detect these resets when they happen, and there is no way to lock the terminal mode against other processes.

## Fix

Keep re-applying the mode we need: the keyboard read loop now re-asserts the wanted terminal mode on every iteration, which runs at least once every 100ms even when there is no input. This must happen even without input, because in cooked mode keystrokes are line buffered by the kernel and never become readable to us.

The `pauseOrRead` semaphore makes sure we never re-assert while the terminal mode has intentionally been restored to cooked, by `PauseAndCall()` (shelling out to `$EDITOR`) or by `Close()` (moor exiting).

Re-assertion is flags-preserving on both platforms: Windows sets/clears only the flags we need (leaving e.g. `ENABLE_QUICK_EDIT_MODE` alone), and Unix goes through `term.MakeRaw()`'s get-modify-set.

As a bonus this fixes a pre-existing Windows bug: `PauseAndCall()` used to permanently lose `ENABLE_VIRTUAL_TERMINAL_INPUT`, so arrow keys stopped working after using <kbd>v</kbd> to edit. The read loop now repairs that within 100ms.

## Testing

* **macOS**: the #443 repro is verified fixed (<kbd>/</kbd> enters search mode after node exits, instead of being echoed). The editor pause path was verified with a cooked-mode line editor (`VISUAL=ed`), and the terminal is correctly restored after moor exits.
* **Windows**: cross-compiles and unit tests pass, but manual verification is still pending — testers with a #394-style setup are very welcome to try a build of this branch.

Fixes #394
Fixes #443

---

*This PR was largely written by an AI (Claude Code, model Claude Fable 5), directed and reviewed by @walles.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
