### PR TITLE
add line number argument for specific editors

### DIFF
--- a/internal/editor.go
+++ b/internal/editor.go
@@ -118,7 +118,7 @@ func editorAcceptsPlusLine(editorCommand string) bool {
 
 	// hardcode known editors for now
 	switch base {
-	case "vim", "vi", "nvim", "nano", "emacs":
+	case "vim", "vi", "nvim", "nano", "pico", "emacs":
 		return true
 	}
 	return false

--- a/internal/editor.go
+++ b/internal/editor.go
@@ -111,6 +111,17 @@ func pickAnEditor() (string, string, error) {
 	return "", "", fmt.Errorf("No editor found, tried: $VISUAL, $EDITOR, %s", strings.Join(candidates, ", "))
 }
 
+// Returns nil if nothing is being shown.
+func middleVisibleLine(p *Pager) *linemetadata.Index {
+	lines := p.renderLines().lines
+	if len(lines) == 0 {
+		return nil
+	}
+
+	middle := lines[len(lines)/2].inputLineIndex
+	return &middle
+}
+
 // check if the editor can accept "+LINENUMBER" argument
 func editorAcceptsPlusLine(editorCommand string) bool {
 	base := strings.ToLower(filepath.Base(editorCommand))
@@ -202,8 +213,12 @@ func handleEditingRequest(p *Pager) {
 
 		lineInfo := ""
 		// add line number argument if editor is supported
-		if topLine := p.lineIndex(); topLine != nil && editorAcceptsPlusLine(commandWithArgs[0]) {
-			lineNumber := topLine.Index() + 1
+		//
+		// vim / nano / etc all center the requested line on screen, so aim for
+		// the middle of moor's screen to match what the user was actually
+		// looking at.
+		if middleLine := middleVisibleLine(p); middleLine != nil && editorAcceptsPlusLine(commandWithArgs[0]) {
+			lineNumber := middleLine.Index() + 1
 			lineInfo = fmt.Sprintf(" (at line %d)", lineNumber)
 			commandWithArgs = append(commandWithArgs, fmt.Sprintf("+%d", lineNumber))
 		}

--- a/internal/editor.go
+++ b/internal/editor.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 
@@ -110,6 +111,19 @@ func pickAnEditor() (string, string, error) {
 	return "", "", fmt.Errorf("No editor found, tried: $VISUAL, $EDITOR, %s", strings.Join(candidates, ", "))
 }
 
+// check if the editor can accept "+LINENUMBER" argument
+func editorAcceptsPlusLine(editorCommand string) bool {
+	base := strings.ToLower(filepath.Base(editorCommand))
+	base = strings.TrimSuffix(base, ".exe")
+
+	// hardcode known editors for now
+	switch base {
+	case "vim", "vi", "nvim", "nano", "emacs":
+		return true
+	}
+	return false
+}
+
 func handleEditingRequest(p *Pager) {
 	if os.Getenv("LESSSECURE") == "1" {
 		p.mode = &PagerModeInfo{
@@ -185,9 +199,18 @@ func handleEditingRequest(p *Pager) {
 		// NOTE: If you do any changes here, make sure they work with both "nano"
 		// and "code -w" (VSCode).
 		commandWithArgs := strings.Fields(editor)
+
+		lineInfo := ""
+		// add line number argument if editor is supported
+		if topLine := p.lineIndex(); topLine != nil && editorAcceptsPlusLine(commandWithArgs[0]) {
+			lineNumber := topLine.Index() + 1
+			lineInfo = fmt.Sprintf(" (at line %d)", lineNumber)
+			commandWithArgs = append(commandWithArgs, fmt.Sprintf("+%d", lineNumber))
+		}
+
 		commandWithArgs = append(commandWithArgs, fileToEdit)
 
-		log.Info("'v' pressed, launching editor: ", commandWithArgs)
+		log.Info("'v' pressed, launching editor", lineInfo, ": ", commandWithArgs)
 		command := exec.Command(commandWithArgs[0], commandWithArgs[1:]...)
 
 		if runtime.GOOS == "windows" {


### PR DESCRIPTION
nice when scrolling down in the pager and pressing `v` to go to the line number in your editor

for now i've only added specific editors i know support the argument to avoid breaking the pager for others