### PR TITLE
Count cells, not input runes, against the cells limit

### DIFF
--- a/internal/textstyles/ansiTokenizer.go
+++ b/internal/textstyles/ansiTokenizer.go
@@ -63,7 +63,7 @@ func StripFormatting(s string, lineIndex linemetadata.Index) string {
 	stripped.Grow(len(s)) // This makes BenchmarkStripFormatting 6% faster
 	runeCount := 0
 
-	styledStringsFromString(twin.StyleDefault, s, &lineIndex, 0, func(str string, style twin.Style) {
+	styledStringsFromString(twin.StyleDefault, s, &lineIndex, 0, func(str string, style twin.Style) int {
 		for _, runeValue := range runesFromStyledString(_StyledString{String: str, Style: style}) {
 			switch runeValue {
 
@@ -103,6 +103,8 @@ func StripFormatting(s string, lineIndex linemetadata.Index) string {
 				runeCount++
 			}
 		}
+
+		return runeCount
 	})
 
 	return stripped.String()
@@ -130,8 +132,17 @@ func StyledRunesFromString(plainTextStyle twin.Style, s string, lineIndex *linem
 	// Specs: https://en.wikipedia.org/wiki/ANSI_escape_code#3-bit_and_4-bit
 	styleUnprintable := twin.StyleDefault.WithBackground(twin.NewColor16(1)).WithForeground(twin.NewColor16(7))
 
-	trailer := styledStringsFromString(plainTextStyle, s, lineIndex, maxCellsCount, func(str string, style twin.Style) {
-		for _, token := range tokensFromStyledString(_StyledString{String: str, Style: style}, maxCellsCount) {
+	trailer := styledStringsFromString(plainTextStyle, s, lineIndex, maxCellsCount, func(str string, style twin.Style) int {
+		// Ask only for the cells we still have room for
+		remainingCellsCount := 0 // Zero means no limit
+		if maxCellsCount > 0 {
+			remainingCellsCount = maxCellsCount - len(cells)
+			if remainingCellsCount <= 0 {
+				return len(cells)
+			}
+		}
+
+		for _, token := range tokensFromStyledString(_StyledString{String: str, Style: style}, remainingCellsCount) {
 			switch token.Rune {
 
 			case '\x09': // TAB
@@ -193,6 +204,8 @@ func StyledRunesFromString(plainTextStyle twin.Style, s string, lineIndex *linem
 				})
 			}
 		}
+
+		return len(cells)
 	})
 
 	return StyledRunesWithTrailer{

--- a/internal/textstyles/ansiTokenizer.go
+++ b/internal/textstyles/ansiTokenizer.go
@@ -143,6 +143,12 @@ func StyledRunesFromString(plainTextStyle twin.Style, s string, lineIndex *linem
 		}
 
 		for _, token := range tokensFromStyledString(_StyledString{String: str, Style: style}, remainingCellsCount) {
+			if maxCellsCount > 0 && len(cells) >= maxCellsCount {
+				// Enough cells. We check here rather than trusting the token
+				// count, because one token can render as several cells.
+				break
+			}
+
 			switch token.Rune {
 
 			case '\x09': // TAB

--- a/internal/textstyles/ansiTokenizer_test.go
+++ b/internal/textstyles/ansiTokenizer_test.go
@@ -409,6 +409,24 @@ func TestManPageFormattingDeliversRequestedCellsCount(t *testing.T) {
 	}
 }
 
+// A TAB is one input rune rendering as up to TabSize cells, so tab expansion
+// must stop once the cells limit is reached. The final TAB is rendered up to its
+// tab stop rather than cut in half, so the result can overshoot by up to
+// TabSize-1 cells. What it must not do is scale with the length of the line.
+func TestTabExpansionRespectsCellsLimit(t *testing.T) {
+	const requestedCellsCount = 10
+
+	// Far more tabs than the limit leaves room for
+	line := strings.Repeat("\t", 500)
+
+	styled := StyledRunesFromString(twin.StyleDefault, line, nil, requestedCellsCount).StyledRunes
+
+	assert.Assert(t, len(styled) >= requestedCellsCount,
+		"got %d cells, want at least the %d requested", len(styled), requestedCellsCount)
+	assert.Assert(t, len(styled) < requestedCellsCount+TabSize,
+		"got %d cells, want fewer than %d", len(styled), requestedCellsCount+TabSize)
+}
+
 // Benchmark stripping formatting from a colored git diff sample.
 // To run:
 //

--- a/internal/textstyles/ansiTokenizer_test.go
+++ b/internal/textstyles/ansiTokenizer_test.go
@@ -380,6 +380,35 @@ func TestIssue372(t *testing.T) {
 	assert.Equal(t, len(styled), maxCellsCount)
 }
 
+// The cells count budget is in cells, not in input runes. Man page backspace
+// formatting puts several input runes into one cell, so a line mixing that with
+// ANSI escape sequences must still deliver the full requested number of cells.
+//
+// The escape sequence matters: the budget is only consulted at part boundaries,
+// and a line with no escapes at all takes a plain text shortcut.
+func TestManPageFormattingDeliversRequestedCellsCount(t *testing.T) {
+	const requestedCellsCount = 10
+
+	// Nine cells worth of man page formatting, each cell made from more than one
+	// input rune
+	prefixes := map[string]string{
+		// Five runes per cell: '_', backspace, 𝕏, backspace, 𝕏
+		"bold underline": strings.Repeat("_\b\U0001D54F\b\U0001D54F", 9),
+
+		// Seven runes per cell: '+', backspace, '+', backspace, 'o', backspace, 'o'
+		"bullet": strings.Repeat("+\b+\bo\bo", 9),
+	}
+
+	for name, prefix := range prefixes {
+		t.Run(name, func(t *testing.T) {
+			line := prefix + "\x1b[31m" + strings.Repeat("x", 5000)
+
+			styled := StyledRunesFromString(twin.StyleDefault, line, nil, requestedCellsCount).StyledRunes
+			assert.Equal(t, len(styled), requestedCellsCount)
+		})
+	}
+}
+
 // Benchmark stripping formatting from a colored git diff sample.
 // To run:
 //

--- a/internal/textstyles/styledStringSplitter.go
+++ b/internal/textstyles/styledStringSplitter.go
@@ -17,8 +17,7 @@ type styledStringSplitter struct {
 	lineIndex      *linemetadata.Index // Used for error reporting
 	plainTextStyle twin.Style
 
-	maxReportedRunesCount int
-	reportedRunesCount    int
+	maxCellsCount int
 
 	nextByteIndex     int
 	previousByteIndex int
@@ -29,21 +28,23 @@ type styledStringSplitter struct {
 
 	trailer twin.Style
 
-	callback func(str string, style twin.Style)
+	// Returns the total number of cells rendered so far, counting all calls.
+	// Compared against maxCellsCount.
+	callback func(str string, style twin.Style) int
 }
 
 // Returns the style of the line's trailer.
 //
 // The lineIndex is only used for error reporting.
 //
-// maxReportedRunesCount: stop parsing once this many input runes have been
-// reported to the callback. If 0, there is no limit. For
-// BenchmarkRenderHugeLine() performance.
+// The callback must return the total number of cells it has rendered so far,
+// counting all calls. We can't count that ourselves: input runes are not cells,
+// since man page backspace sequences take several input runes per cell, and a
+// TAB takes one input rune but renders as several cells.
 //
-// Note that input runes are not cells: man page backspace sequences take
-// several input runes per cell, and a TAB takes one input rune but renders as
-// several cells.
-func styledStringsFromString(plainTextStyle twin.Style, s string, lineIndex *linemetadata.Index, maxReportedRunesCount int, callback func(string, twin.Style)) twin.Style {
+// maxCellsCount: stop parsing once the callback reports this many cells. If 0,
+// there is no limit. For BenchmarkRenderHugeLine() performance.
+func styledStringsFromString(plainTextStyle twin.Style, s string, lineIndex *linemetadata.Index, maxCellsCount int, callback func(string, twin.Style) int) twin.Style {
 	if !strings.ContainsAny(s, "\x1b") {
 		// This shortcut makes BenchmarkPlainTextSearch() perform a lot better
 		callback(s, plainTextStyle)
@@ -51,13 +52,13 @@ func styledStringsFromString(plainTextStyle twin.Style, s string, lineIndex *lin
 	}
 
 	splitter := styledStringSplitter{
-		input:                 s,
-		lineIndex:             lineIndex,
-		plainTextStyle:        plainTextStyle, // How plain text should be styled
-		maxReportedRunesCount: maxReportedRunesCount,
-		inProgressStyle:       plainTextStyle, // Plain text style until something else comes along
-		callback:              callback,
-		trailer:               plainTextStyle, // Plain text style until something else comes along
+		input:           s,
+		lineIndex:       lineIndex,
+		plainTextStyle:  plainTextStyle, // How plain text should be styled
+		maxCellsCount:   maxCellsCount,
+		inProgressStyle: plainTextStyle, // Plain text style until something else comes along
+		callback:        callback,
+		trailer:         plainTextStyle, // Plain text style until something else comes along
 	}
 	splitter.run()
 
@@ -478,12 +479,10 @@ func (s *styledStringSplitter) finalizeCurrentPart() {
 		return
 	}
 
-	partString := s.inProgressString.String()
-	s.callback(partString, s.inProgressStyle)
-	s.reportedRunesCount += utf8.RuneCountInString(partString)
+	totalCellsCount := s.callback(s.inProgressString.String(), s.inProgressStyle)
 
-	if s.maxReportedRunesCount > 0 && s.reportedRunesCount >= s.maxReportedRunesCount {
-		// We've reported enough runes, stop processing any further input
+	if s.maxCellsCount > 0 && totalCellsCount >= s.maxCellsCount {
+		// We've reported enough cells, stop processing any further input
 		s.nextByteIndex = len(s.input)
 	}
 }

--- a/internal/textstyles/styledStringSplitter_test.go
+++ b/internal/textstyles/styledStringSplitter_test.go
@@ -30,8 +30,11 @@ func TestNextCharLastChar_empty(t *testing.T) {
 
 func collectStyledStrings(s string) ([]_StyledString, twin.Style) {
 	styledStrings := []_StyledString{}
-	trailer := styledStringsFromString(twin.StyleDefault, s, nil, 0, func(str string, style twin.Style) {
+	trailer := styledStringsFromString(twin.StyleDefault, s, nil, 0, func(str string, style twin.Style) int {
 		styledStrings = append(styledStrings, _StyledString{str, style})
+
+		// We render no cells, and we asked for no limit
+		return 0
 	})
 	return styledStrings, trailer
 }
@@ -137,8 +140,11 @@ func TestURLWithEmptyID(t *testing.T) {
 func TestPlainTextColor(t *testing.T) {
 	plainTextStyle := twin.StyleDefault.WithAttr(twin.AttrReverse)
 	styledStrings := []_StyledString{}
-	trailer := styledStringsFromString(plainTextStyle, "a\x1b[33mb\x1b[mc", nil, 0, func(str string, style twin.Style) {
+	trailer := styledStringsFromString(plainTextStyle, "a\x1b[33mb\x1b[mc", nil, 0, func(str string, style twin.Style) int {
 		styledStrings = append(styledStrings, _StyledString{str, style})
+
+		// We render no cells, and we asked for no limit
+		return 0
 	})
 
 	assert.Equal(t, 3, len(styledStrings))


### PR DESCRIPTION
The cells count limit was checked against a count of input runes. Runes are
not cells: man page backspace formatting spends five input runes (`_\bx\bx`,
a bold underlined `x`) or seven (`+\b+\bo\bo`, a bullet) on a single cell. So
the limit was reached long before that many cells had been produced, and the
rest of the line was thrown away.

An escape sequence is needed to trigger it, because the limit is only
consulted at a part boundary, and a line with no escapes at all takes the
plain text shortcut higher up instead.

**User visible symptom:** characters dropped off the right hand edge of man
page formatted lines that also contain ANSI escape sequences, when not
wrapping — that path asks for screen width plus left column plus one cells.
Wrap mode passes no limit and was never affected.

## Requested vs delivered

| requested | man page formatting | tabs only |
| --------- | ------------------- | --------- |
| 1         | 1 → 1               | 8 → 8     |
| 5         | 5 → 5               | 40 → 8    |
| 10        | **9 → 10**          | 80 → 16   |
| 20        | **9 → 20**          | 160 → 24  |

## The fix

Only the callback knows how many cells a part rendered into, so it now
reports that back and the splitter goes by what it says. Two consequences
worth reviewing:

- The callback signature gained an `int` return, documented on both the
  struct field and `styledStringsFromString()`. The two test collectors that
  render no cells return 0.
- The per-part call asked for the full limit rather than the remaining
  budget, so a second part started counting from zero. It now asks for what
  is left.

The third commit fixes the same wrong-unit mistake pointing the other way:
`tokensFromStyledString()` was asked for a *token* count, but a TAB token
renders as up to `TabSize` cells, so a line of tabs produced up to eight
times the cells asked for. That one is pre-existing and unrelated to the
under-delivery — it reproduces identically on master.

## Known remaining rough edges

- `maxCellsCount` is still not a strict maximum. A trailing TAB renders up to
  its tab stop rather than being cut in half, so the result can exceed the
  limit by up to `TabSize-1` cells. It no longer scales with line length,
  which is what the limit exists to bound.
- Separate pre-existing issue, not addressed here: `Width()` returns 0 for
  combining marks, so asking for `width+1` cells does not strictly guarantee
  `width` columns are covered. The same dropped-characters symptom is still
  reachable that way.

## Validation

`MOOR_SKIP_INTERACTIVE_TESTS=1 ./test.sh` passes. `BenchmarkRenderHugeLine`
is unchanged within noise (901µs before, 917µs after; three runs spanned
867–917µs, so the spread exceeds the difference).

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Opus 5)
