### PR TITLE
Make rendering huge lines independent of line length

### DIFF
--- a/internal/reader/line.go
+++ b/internal/reader/line.go
@@ -2,6 +2,7 @@ package reader
 
 import (
 	"sync/atomic"
+	"unsafe"
 
 	"github.com/walles/moor/v2/internal/linemetadata"
 	"github.com/walles/moor/v2/internal/search"
@@ -12,6 +13,16 @@ import (
 type Line struct {
 	raw            []byte
 	plainTextCache atomic.Pointer[string] // Use line.Plain() to access this field
+}
+
+// The raw bytes as a string. Not copied, so the result is a view of the line as
+// it looks right now; appending to the line does not extend it.
+//
+// Performance sensitive, see BenchmarkRenderHugeLine().
+func (line *Line) rawString() string {
+	// Safe because the first len(line.raw) bytes never change: raw only ever
+	// grows by appending, which writes past len(), never below it.
+	return unsafe.String(unsafe.SliceData(line.raw), len(line.raw))
 }
 
 // Returns a representation of the string split into styled tokens. Any regexp
@@ -37,7 +48,7 @@ func (line *Line) HighlightedTokens(
 		matchRanges = activeSearch.GetMatchRanges(plain)
 	}
 
-	fromString := textstyles.StyledRunesFromString(plainTextStyle, string(line.raw), &lineIndex, maxCellsCount)
+	fromString := textstyles.StyledRunesFromString(plainTextStyle, line.rawString(), &lineIndex, maxCellsCount)
 	returnRunes := make([]textstyles.CellWithMetadata, 0, len(fromString.StyledRunes))
 	lastWasSearchHit := false
 	for _, token := range fromString.StyledRunes {
@@ -65,7 +76,7 @@ func (line *Line) HighlightedTokens(
 }
 
 func (line *Line) HasManPageFormatting() bool {
-	return textstyles.HasManPageFormatting(string(line.raw))
+	return textstyles.HasManPageFormatting(line.rawString())
 }
 
 // The index is for error reporting. Set DisablePlainCachingForBenchmarking to
@@ -80,7 +91,7 @@ func (line *Line) Plain(index linemetadata.Index) string {
 		return *fromCache
 	}
 
-	plain := textstyles.StripFormatting(string(line.raw), index)
+	plain := textstyles.StripFormatting(line.rawString(), index)
 
 	// If this succeeds, all good. If it fails it means some other goroutine
 	// populated the cache before us, which is also fine.

--- a/internal/textstyles/ansiTokenizer.go
+++ b/internal/textstyles/ansiTokenizer.go
@@ -34,8 +34,14 @@ var TabSize = 8
 const BACKSPACE = '\b'
 
 type StyledRunesWithTrailer struct {
-	StyledRunes       []CellWithMetadata
-	Trailer           twin.Style
+	StyledRunes []CellWithMetadata
+
+	// Style for padding the rest of the screen row, once StyledRunes run out. A
+	// "clear to end of line" escape sequence in the input sets this, so that the
+	// cleared part of the row gets the style that was in effect. twin.StyleDefault
+	// means no padding is needed.
+	Trailer twin.Style
+
 	ContainsSearchHit bool
 }
 
@@ -117,6 +123,10 @@ func StripFormatting(s string, lineIndex linemetadata.Index) string {
 //
 // maxCellsCount: at most this many cells will be included in the result. If 0,
 // there is no limit. For BenchmarkRenderHugeLine() performance.
+//
+// With a limit set, the returned Trailer is only accurate if fewer than
+// maxCellsCount cells came back. A full result fills the row, so there is
+// nothing left for the trailer to paint.
 func StyledRunesFromString(plainTextStyle twin.Style, s string, lineIndex *linemetadata.Index, maxCellsCount int) StyledRunesWithTrailer {
 	manPageHeading := manPageHeadingFromString(s)
 	if manPageHeading != nil {

--- a/internal/textstyles/ansiTokenizer_test.go
+++ b/internal/textstyles/ansiTokenizer_test.go
@@ -427,6 +427,42 @@ func TestTabExpansionRespectsCellsLimit(t *testing.T) {
 		"got %d cells, want fewer than %d", len(styled), requestedCellsCount+TabSize)
 }
 
+// Cutting a render short at the cells limit must not change the cells we do
+// deliver: a limited render is a prefix of an unlimited one, also when the
+// escape sequences sit beyond the bytes we scan for them.
+func TestCellsLimitOnlyTruncates(t *testing.T) {
+	// The prefixes below are one cell short of this, so they probe all but one
+	// percent of the byte budget. Enough that a maxBytesPerCell one single byte
+	// too small still fails this test.
+	const requestedCellsCount = 100
+
+	// Each prefix renders as requestedCellsCount-1 cells, so the escape sequence
+	// right after it still lands inside the requested range
+	prefixes := map[string]string{
+		"plain": strings.Repeat("x", requestedCellsCount-1),
+
+		// The densest cell there is, eleven bytes: see maxBytesPerCell
+		"bold underline": strings.Repeat("_\b\U0001D54F\b\U0001D54F", requestedCellsCount-1),
+	}
+
+	for name, prefix := range prefixes {
+		t.Run(name, func(t *testing.T) {
+			// Something red after the prefix, then twice the escape sequence scan
+			// window worth of text, so that the scan really does get cut short
+			line := prefix + "\x1b[31m" + strings.Repeat("y", 2*requestedCellsCount*maxBytesPerCell)
+
+			unlimited := StyledRunesFromString(twin.StyleDefault, line, nil, 0).StyledRunes
+			limited := StyledRunesFromString(twin.StyleDefault, line, nil, requestedCellsCount).StyledRunes
+
+			assert.Equal(t, len(limited), requestedCellsCount)
+			assert.DeepEqual(t,
+				limited,
+				unlimited[:requestedCellsCount],
+				cmp.AllowUnexported(twin.Style{}))
+		})
+	}
+}
+
 // Benchmark stripping formatting from a colored git diff sample.
 // To run:
 //

--- a/internal/textstyles/styledStringSplitter.go
+++ b/internal/textstyles/styledStringSplitter.go
@@ -12,6 +12,17 @@ import (
 
 const esc = '\x1b'
 
+// Safe upper bound on how many input bytes can go into one screen cell. On a
+// man page, when there are no escape sequences involved: at most seven runes
+// per cell (the man page bullet '+', backspace, '+', backspace, 'o', backspace,
+// 'o'), at most utf8.UTFMax bytes per rune.
+//
+// Loose on purpose, since those two maxima cannot co-occur: bullets are ASCII.
+// The densest cell really is a bold underlined four byte rune ('_', backspace,
+// 𝕏, backspace, 𝕏) at eleven bytes. Erring high only costs a few scanned
+// bytes, erring low renders the wrong thing.
+const maxBytesPerCell = 7 * utf8.UTFMax
+
 type styledStringSplitter struct {
 	input          string
 	lineIndex      *linemetadata.Index // Used for error reporting
@@ -44,8 +55,21 @@ type styledStringSplitter struct {
 //
 // maxCellsCount: stop parsing once the callback reports this many cells. If 0,
 // there is no limit. For BenchmarkRenderHugeLine() performance.
+//
+// With a limit set, the returned trailer is only accurate if fewer than
+// maxCellsCount cells were reported. A full result fills the row, so there is
+// nothing left for the trailer to paint.
 func styledStringsFromString(plainTextStyle twin.Style, s string, lineIndex *linemetadata.Index, maxCellsCount int, callback func(string, twin.Style) int) twin.Style {
-	if !strings.ContainsAny(s, "\x1b") {
+	// Escape sequences past this window cannot affect any cell we report, see
+	// maxBytesPerCell. Performance sensitive, see BenchmarkRenderHugeLine() and
+	// TestCellsLimitOnlyTruncates().
+	escapeScanWindow := s
+	windowSize := maxCellsCount * maxBytesPerCell
+	if maxCellsCount > 0 && windowSize < len(s) {
+		escapeScanWindow = s[:windowSize]
+	}
+
+	if !strings.ContainsRune(escapeScanWindow, esc) {
 		// This shortcut makes BenchmarkPlainTextSearch() perform a lot better
 		callback(s, plainTextStyle)
 		return plainTextStyle


### PR DESCRIPTION
Follow-up to #358. Reading huge lines is already linear; this makes *rendering* a non-wrapped one cost nothing in the length of the line.

Two independent changes, measured separately on a 5MB line with `BenchmarkRenderHugeLine`:

| | ns/op | B/op |
|---|---|---|
| master | 844,000 | 5,270,838 |
| + stop copying the line per render | 141,000 | 19,282 |
| + stop scanning the whole line for escapes | **9,800** | **19,282** |

**Stop copying every line on every render.** `Line.HighlightedTokens()` did `string(line.raw)`, so every frame allocated a fresh copy of the whole line — 5.27MB per frame here, and the resulting GC pressure dominated the profile. The bytes behind an existing `Line` never change (`raw` only ever grows by appending, which writes past `len()` and never below it), so a zero-copy `unsafe.String()` view is safe.

**Stop scanning whole lines for escape sequences.** With the copy gone, `strings.ContainsAny(s, "\x1b")` was 80% of what remained: it reads every byte to decide whether the plain-text shortcut applies. A cell is rendered from at most `maxBytesPerCell` bytes, so escape sequences further out than that many bytes per requested cell cannot affect any cell we report. Looking only inside that window is enough.

`maxBytesPerCell` is deliberately a loose upper bound (7 runes/cell × `utf8.UTFMax`). `TestCellsLimitOnlyTruncates` pins that it is wide enough: a limited render must come out as a prefix of an unlimited one. It fails if the bound is set to 10 and passes at 11, which is the real worst case (`_`, backspace, 𝕏, backspace, 𝕏).

### What this does *not* fix

A line carrying an escape sequence early on is not helped at all — the splitter buffers the whole line into `inProgressString` before the cells limit gets a chance to stop it. Measured at the `StyledRunesFromString` level:

| 5MB line | ns/op | B/op |
|---|---|---|
| plain | 8,900 | 8,408 |
| leading `ESC[31m` | 30,600,000 | 26,516,456 |

Details and the other remaining costs are in a comment on #358.

Validated with `MOOR_SKIP_INTERACTIVE_TESTS=1 ./test.sh`, plus `go test -race ./...` and `gofmt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Opus 5)
