### PR TITLE
Stop buffering huge ANSI styled lines

### DIFF
--- a/internal/textstyles/ansiTokenizer_test.go
+++ b/internal/textstyles/ansiTokenizer_test.go
@@ -463,6 +463,26 @@ func TestCellsLimitOnlyTruncates(t *testing.T) {
 	}
 }
 
+// Escape sequences cost input bytes but render no cells, so a line can carry
+// arbitrarily many of them before its first visible cell. The cells limit must
+// still deliver the cells that are there.
+func TestCellsLimitCountsCellsNotEscapeBytes(t *testing.T) {
+	const requestedCellsCount = 4
+
+	// Red on, red off, over and over. Renders nothing, while taking up many times
+	// the requested cells' worth of input bytes.
+	noopEscapes := strings.Repeat("\x1b[31m\x1b[m", requestedCellsCount*maxBytesPerCell)
+	line := noopEscapes + "\x1b[1m" + strings.Repeat("x", requestedCellsCount)
+
+	styled := StyledRunesFromString(twin.StyleDefault, line, nil, requestedCellsCount).StyledRunes
+
+	assert.Equal(t, len(styled), requestedCellsCount)
+	for _, cell := range styled {
+		assert.Equal(t, cell.Rune, 'x')
+		assert.Equal(t, cell.Style, twin.StyleDefault.WithAttr(twin.AttrBold))
+	}
+}
+
 // Man pages are pre-formatted to the terminal width, so their overstrike
 // formatting always sits near the start of a line. Detection only scans that
 // far, which keeps it cheap on lines that are not man page formatting at all.

--- a/internal/textstyles/ansiTokenizer_test.go
+++ b/internal/textstyles/ansiTokenizer_test.go
@@ -565,3 +565,17 @@ func BenchmarkStripFormattingUnformattedInput(b *testing.B) {
 		}
 	}
 }
+
+// A huge line starting with an escape sequence. Lines with no escape sequences
+// have a shortcut in styledStringsFromString(); this benchmark measures what
+// happens when we can't take it.
+func BenchmarkStyledRunesFromHugeAnsiLine(b *testing.B) {
+	line := "\x1b[31m" + strings.Repeat("x", 5*1024*1024)
+	b.SetBytes(int64(len(line)))
+
+	for b.Loop() {
+		// 81 is what an 80 column terminal asks for, see HighlightedTokens()
+		// callers
+		StyledRunesFromString(twin.StyleDefault, line, nil, 81)
+	}
+}

--- a/internal/textstyles/ansiTokenizer_test.go
+++ b/internal/textstyles/ansiTokenizer_test.go
@@ -526,8 +526,8 @@ func BenchmarkStripFormatting(b *testing.B) {
 	lines := strings.Split(string(data), "\n")
 	// Set processed bytes per iteration
 	b.SetBytes(int64(len(data)))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		for _, line := range lines {
 			// We ignore the output; benchmarking execution time only
 			_ = StripFormatting(line, linemetadata.Index{})
@@ -557,8 +557,8 @@ func BenchmarkStripFormattingUnformattedInput(b *testing.B) {
 	lines := strings.Split(unformatted.String(), "\n")
 	// Set processed bytes per iteration
 	b.SetBytes(int64(len(unformatted.String())))
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	for b.Loop() {
 		for _, line := range lines {
 			// We ignore the output; benchmarking execution time only
 			_ = StripFormatting(line, linemetadata.Index{})

--- a/internal/textstyles/styledStringSplitter.go
+++ b/internal/textstyles/styledStringSplitter.go
@@ -158,7 +158,6 @@ func (s *styledStringSplitter) handleRune(char rune) {
 	// cells even in the densest supported format, let the callback stop us.
 	if s.maxCellsCount > 0 && s.inProgressString.Len() >= s.maxCellsCount*maxBytesPerCell {
 		s.finalizeCurrentPart()
-		s.inProgressString.Reset()
 	}
 }
 
@@ -501,10 +500,14 @@ func (s *styledStringSplitter) startNewPart(style twin.Style) {
 	}
 
 	s.finalizeCurrentPart()
-	s.inProgressString.Reset()
 	s.inProgressStyle = style
 }
 
+// Report whatever we have buffered to the callback, and empty the buffer.
+//
+// Resetting rather than truncating matters: the string we hand the callback
+// shares the builder's buffer, and Reset() replaces that buffer instead of
+// writing over it.
 func (s *styledStringSplitter) finalizeCurrentPart() {
 	if s.inProgressString.Len() == 0 {
 		// Nothing to do
@@ -512,6 +515,7 @@ func (s *styledStringSplitter) finalizeCurrentPart() {
 	}
 
 	totalCellsCount := s.callback(s.inProgressString.String(), s.inProgressStyle)
+	s.inProgressString.Reset()
 
 	if s.maxCellsCount > 0 && totalCellsCount >= s.maxCellsCount {
 		// We've reported enough cells, stop processing any further input

--- a/internal/textstyles/styledStringSplitter.go
+++ b/internal/textstyles/styledStringSplitter.go
@@ -34,6 +34,10 @@ type styledStringSplitter struct {
 	// callback a chance to stop us. 0 means never.
 	flushAtBytes int
 
+	// Set once the callback has reported all the cells we were asked for. No
+	// remaining input can affect the result, so we stop looking at it.
+	done bool
+
 	nextByteIndex     int
 	previousByteIndex int
 
@@ -123,7 +127,7 @@ func (s *styledStringSplitter) lastChar() rune {
 func (s *styledStringSplitter) run() {
 	char := s.nextChar()
 	for {
-		if char == -1 {
+		if char == -1 || s.done {
 			s.finalizeCurrentPart()
 			return
 		}
@@ -145,6 +149,9 @@ func (s *styledStringSplitter) run() {
 				// character as just plain runes.
 				for _, char := range s.input[escIndex:s.previousByteIndex] {
 					s.handleRune(char)
+					if s.done {
+						break
+					}
 				}
 
 				// Start over with the character that caused the problem
@@ -512,7 +519,8 @@ func (s *styledStringSplitter) startNewPart(style twin.Style) {
 	s.inProgressStyle = style
 }
 
-// Report whatever we have buffered to the callback, and empty the buffer.
+// Report whatever we have buffered to the callback, and empty the buffer. Sets
+// done if the callback has now rendered all the cells we were asked for.
 //
 // Resetting rather than truncating matters: the string we hand the callback
 // shares the builder's buffer, and Reset() replaces that buffer instead of
@@ -527,7 +535,6 @@ func (s *styledStringSplitter) finalizeCurrentPart() {
 	s.inProgressString.Reset()
 
 	if s.maxCellsCount > 0 && totalCellsCount >= s.maxCellsCount {
-		// We've reported enough cells, stop processing any further input
-		s.nextByteIndex = len(s.input)
+		s.done = true
 	}
 }

--- a/internal/textstyles/styledStringSplitter.go
+++ b/internal/textstyles/styledStringSplitter.go
@@ -152,6 +152,14 @@ func (s *styledStringSplitter) run() {
 
 func (s *styledStringSplitter) handleRune(char rune) {
 	s.inProgressString.WriteRune(char)
+
+	// A long run with no style changes would otherwise stay buffered until the
+	// end of the line. Once we have enough input bytes to fill the requested
+	// cells even in the densest supported format, let the callback stop us.
+	if s.maxCellsCount > 0 && s.inProgressString.Len() >= s.maxCellsCount*maxBytesPerCell {
+		s.finalizeCurrentPart()
+		s.inProgressString.Reset()
+	}
 }
 
 func (s *styledStringSplitter) handleEscape() error {

--- a/internal/textstyles/styledStringSplitter.go
+++ b/internal/textstyles/styledStringSplitter.go
@@ -30,6 +30,10 @@ type styledStringSplitter struct {
 
 	maxCellsCount int
 
+	// Report the current part once it has buffered this many bytes, giving the
+	// callback a chance to stop us. 0 means never.
+	flushAtBytes int
+
 	nextByteIndex     int
 	previousByteIndex int
 
@@ -60,13 +64,17 @@ type styledStringSplitter struct {
 // maxCellsCount cells were reported. A full result fills the row, so there is
 // nothing left for the trailer to paint.
 func styledStringsFromString(plainTextStyle twin.Style, s string, lineIndex *linemetadata.Index, maxCellsCount int, callback func(string, twin.Style) int) twin.Style {
-	// Escape sequences past this window cannot affect any cell we report, see
-	// maxBytesPerCell. Performance sensitive, see BenchmarkRenderHugeLine() and
+	// The cells we report can only come from this many leading input bytes, see
+	// maxBytesPerCell. So nothing past here can affect our result, neither an
+	// escape sequence nor more text. 0 means no limit was requested.
+	//
+	// Performance sensitive, see BenchmarkRenderHugeLine() and
 	// TestCellsLimitOnlyTruncates().
+	relevantBytesCount := maxCellsCount * maxBytesPerCell
+
 	escapeScanWindow := s
-	windowSize := maxCellsCount * maxBytesPerCell
-	if maxCellsCount > 0 && windowSize < len(s) {
-		escapeScanWindow = s[:windowSize]
+	if relevantBytesCount > 0 && relevantBytesCount < len(s) {
+		escapeScanWindow = s[:relevantBytesCount]
 	}
 
 	if !strings.ContainsRune(escapeScanWindow, esc) {
@@ -80,6 +88,7 @@ func styledStringsFromString(plainTextStyle twin.Style, s string, lineIndex *lin
 		lineIndex:       lineIndex,
 		plainTextStyle:  plainTextStyle, // How plain text should be styled
 		maxCellsCount:   maxCellsCount,
+		flushAtBytes:    relevantBytesCount,
 		inProgressStyle: plainTextStyle, // Plain text style until something else comes along
 		callback:        callback,
 		trailer:         plainTextStyle, // Plain text style until something else comes along
@@ -154,9 +163,9 @@ func (s *styledStringSplitter) handleRune(char rune) {
 	s.inProgressString.WriteRune(char)
 
 	// A long run with no style changes would otherwise stay buffered until the
-	// end of the line. Once we have enough input bytes to fill the requested
-	// cells even in the densest supported format, let the callback stop us.
-	if s.maxCellsCount > 0 && s.inProgressString.Len() >= s.maxCellsCount*maxBytesPerCell {
+	// end of the line. Once we have buffered every byte that could contribute to
+	// the requested cells, let the callback stop us.
+	if s.flushAtBytes > 0 && s.inProgressString.Len() >= s.flushAtBytes {
 		s.finalizeCurrentPart()
 	}
 }

--- a/internal/textstyles/styledStringSplitter_test.go
+++ b/internal/textstyles/styledStringSplitter_test.go
@@ -181,6 +181,32 @@ func TestCellsLimitFlushesLongStyledRun(t *testing.T) {
 	assert.Equal(t, callbackCalls, 1)
 }
 
+// An escape sequence we can't make sense of gets replayed as plain runes. The
+// cells limit should stop that replay as soon as the callback is full, just like
+// it stops ordinary parsing.
+func TestCellsLimitStopsMalformedEscapeReplay(t *testing.T) {
+	const requestedCellsCount = 80
+
+	// "ESC[" followed by parameter bytes and then "z", which is not a CSI type we
+	// handle. Rendering it means replaying all those parameter bytes.
+	line := "\x1b[" + strings.Repeat("3", 5*1024*1024) + "z"
+
+	callbackCalls := 0
+	styledStringsFromString(twin.StyleDefault, line, nil, requestedCellsCount, func(str string, _ twin.Style) int {
+		callbackCalls++
+
+		// The replay starts over from the ESC, so anything we get should come
+		// from the start of the line
+		assert.Assert(t, strings.HasPrefix(line, str),
+			"got %d bytes from somewhere other than the start of the line", len(str))
+
+		// Report the limit as reached, so there is no reason to keep going
+		return requestedCellsCount
+	})
+
+	assert.Equal(t, callbackCalls, 1)
+}
+
 // Ignore G0 charset resets (`ESC(B`). They are output by "tput sgr0" on at
 // least TERM=xterm-256color.
 //

--- a/internal/textstyles/styledStringSplitter_test.go
+++ b/internal/textstyles/styledStringSplitter_test.go
@@ -171,8 +171,7 @@ func TestCellsLimitFlushesLongStyledRun(t *testing.T) {
 	callbackCalls := 0
 	styledStringsFromString(twin.StyleDefault, line, nil, requestedCellsCount, func(str string, _ twin.Style) int {
 		callbackCalls++
-		assert.Assert(t, len(str) <= requestedCellsCount*maxBytesPerCell,
-			"callback got %d bytes, expected at most %d", len(str), requestedCellsCount*maxBytesPerCell)
+		assert.Equal(t, len(str), requestedCellsCount*maxBytesPerCell)
 
 		// All input runes in str are single-cell x characters, so the callback
 		// has rendered the requested number of cells.

--- a/internal/textstyles/styledStringSplitter_test.go
+++ b/internal/textstyles/styledStringSplitter_test.go
@@ -161,6 +161,36 @@ func TestPlainTextColor(t *testing.T) {
 	assert.Equal(t, plainTextStyle, trailer)
 }
 
+// A cells limit should bound how much of a styled run we buffer before asking
+// the callback whether it has rendered enough. Without this, a leading color
+// escape makes us buffer the entire line before the limit can stop parsing.
+func TestCellsLimitFlushesLongStyledRun(t *testing.T) {
+	const requestedCellsCount = 80
+	line := "\x1b[31m" + strings.Repeat("x", 5*1024*1024)
+
+	callbackCalls := 0
+	styledStringsFromString(twin.StyleDefault, line, nil, requestedCellsCount, func(str string, _ twin.Style) int {
+		callbackCalls++
+		assert.Assert(t, len(str) <= requestedCellsCount*maxBytesPerCell,
+			"callback got %d bytes, expected at most %d", len(str), requestedCellsCount*maxBytesPerCell)
+
+		// All input runes in str are single-cell x characters, so the callback
+		// has rendered the requested number of cells.
+		return requestedCellsCount
+	})
+
+	assert.Equal(t, callbackCalls, 1)
+}
+
+func BenchmarkStyledRunesFromHugeAnsiLine(b *testing.B) {
+	line := "\x1b[31m" + strings.Repeat("x", 5*1024*1024)
+	b.SetBytes(int64(len(line)))
+
+	for b.Loop() {
+		StyledRunesFromString(twin.StyleDefault, line, nil, 81)
+	}
+}
+
 // Ignore G0 charset resets (`ESC(B`). They are output by "tput sgr0" on at
 // least TERM=xterm-256color.
 //

--- a/internal/textstyles/styledStringSplitter_test.go
+++ b/internal/textstyles/styledStringSplitter_test.go
@@ -181,15 +181,6 @@ func TestCellsLimitFlushesLongStyledRun(t *testing.T) {
 	assert.Equal(t, callbackCalls, 1)
 }
 
-func BenchmarkStyledRunesFromHugeAnsiLine(b *testing.B) {
-	line := "\x1b[31m" + strings.Repeat("x", 5*1024*1024)
-	b.SetBytes(int64(len(line)))
-
-	for b.Loop() {
-		StyledRunesFromString(twin.StyleDefault, line, nil, 81)
-	}
-}
-
 // Ignore G0 charset resets (`ESC(B`). They are output by "tput sgr0" on at
 // least TERM=xterm-256color.
 //


### PR DESCRIPTION
Follow-up to #358.

A leading ANSI sequence bypassed the plain-text shortcut, after which `styledStringSplitter` buffered the entire same-style run before invoking the cells-counting callback. Flush the run after the existing conservative bytes-per-cell window so the callback can stop parsing once the requested cells are filled.

On Windows/amd64, the 5 MiB leading-SGR benchmark improved from 39.17 ms and 26.5 MB allocated per operation to 37–41 µs and 16.9 KB.

## Testing

- `MOOR_SKIP_INTERACTIVE_TESTS=1 ./test.sh`
- `MOOR_SKIP_INTERACTIVE_TESTS=1 GOARCH=386 ./test.sh`
- Windows `go build -race ./...`
- Windows `go test -race -timeout 60s ./internal/textstyles`
