### PR TITLE
Avoid JSON highlighting for scalar input

### DIFF
--- a/internal/reader/highlight.go
+++ b/internal/reader/highlight.go
@@ -164,7 +164,8 @@ func textAsString(reader *ReaderImpl, shouldFormat bool) string {
 }
 
 func isJsonOrJsonl(text string) bool {
-	if json.Valid([]byte(text)) {
+	trimmed := strings.TrimSpace(text)
+	if len(trimmed) > 0 && (trimmed[0] == '{' || trimmed[0] == '[') && json.Valid([]byte(trimmed)) {
 		return true
 	}
 

--- a/internal/reader/highlight_test.go
+++ b/internal/reader/highlight_test.go
@@ -61,6 +61,7 @@ func TestFormatJsonArray(t *testing.T) {
 func TestIsJsonOrJsonl(t *testing.T) {
 	// Standard JSON
 	assert.Assert(t, isJsonOrJsonl(`{"hello": "world"}`))
+	assert.Assert(t, isJsonOrJsonl(`[1, 2, 3]`))
 
 	// JSONL sample file
 	jsonlPath := filepath.Join("..", "..", "sample-files", "jsonl.jsonl")
@@ -68,4 +69,19 @@ func TestIsJsonOrJsonl(t *testing.T) {
 	assert.NilError(t, err)
 
 	assert.Assert(t, isJsonOrJsonl(string(jsonlBytes)))
+}
+
+func TestJsonScalarIsNotHighlightedAsJson(t *testing.T) {
+	for _, scalar := range []string{
+		"1\n",
+		" 1 \n",
+		"1.1\n",
+		"true\n",
+		"null\n",
+		`"text"`,
+	} {
+		t.Run(scalar, func(t *testing.T) {
+			assert.Assert(t, !isJsonOrJsonl(scalar))
+		})
+	}
 }


### PR DESCRIPTION
Fixes #445.

  Only classify a complete JSON value as JSON when it is an object or array. JSON scalars such as a line containing only a number are valid according to `json.Valid`, but should remain plain text for automatic syntax
  detection.

  JSONL detection is unchanged, and the tests cover arrays plus number, boolean, null, and string scalars.

  ## Testing

  - `go test ./internal/reader -run '^(TestIsJsonOrJsonl|TestJsonScalarIsNotHighlightedAsJson)$'`
  - `gofmt -d internal/reader/highlight.go internal/reader/highlight_test.go`